### PR TITLE
Use (az, el) coordinates for target separation

### DIFF
--- a/katpoint/target.py
+++ b/katpoint/target.py
@@ -669,14 +669,17 @@ class Target(object):
         separation : :class:`ephem.Angle` object, or array of shape of *timestamp*
             Angular separation between the targets, in radians
 
+        Notes
+        -----
+        This calculates the azimuth and elevation of both targets at the given
+        time and finds the angular distance between the two sets of coordinates.
+
         """
         # Get a common timestamp and antenna for both targets
         timestamp, antenna = self._set_timestamp_antenna_defaults(timestamp, antenna)
         def _scalar_separation(t):
             """Calculate angular separation for a single time instant."""
-            # Work in apparent (ra, dec), as this is the most reliable common coordinate frame in ephem
-            return ephem.separation(self.apparent_radec(t, antenna),
-                                    other_target.apparent_radec(t, antenna))
+            return ephem.separation(self.azel(t, antenna), other_target.azel(t, antenna))
         if is_iterable(timestamp):
             return np.array([_scalar_separation(t) for t in timestamp])
         else:

--- a/katpoint/test/test_target.py
+++ b/katpoint/test/test_target.py
@@ -158,6 +158,19 @@ class TestTargetCalculations(unittest.TestCase):
         np.testing.assert_almost_equal(v, -9.1043784587765906, decimal=5)
         np.testing.assert_almost_equal(w, 4.7781625336985198e-10, decimal=5)
 
+    def test_separation(self):
+        """Test separation calculation."""
+        sun = katpoint.Target('Sun, special')
+        az, el = sun.azel(self.ts, self.ant1)
+        azel = katpoint.construct_azel_target(az, el)
+        sep = sun.separation(azel, self.ts, self.ant1)
+        self.assertEqual(sep, 0.0, 'Separation between target and itself is bigger than 0.0')
+        sep = azel.separation(sun, self.ts, self.ant1)
+        self.assertEqual(sep, 0.0, 'Separation between target and itself is bigger than 0.0')
+        azel2 = katpoint.construct_azel_target(az, el + 0.01)
+        sep = azel.separation(azel2, self.ts, self.ant1)
+        np.testing.assert_almost_equal(sep, 0.01, decimal=12)
+
     def test_projection(self):
         """Test projection."""
         az, el = katpoint.deg2rad(50.0), katpoint.deg2rad(80.0)


### PR DESCRIPTION
In the past, the angular separation between two targets was found
based on their apparent (ra, dec) coordinates, motivated by a cryptic
comment in the code that calls this "the most reliable common
coordinate frame in ephem". I cannot remember why this should be so.

Use good old (az, el) instead, as all targets have to provide this for
the telescope. The problem with apparent (ra, dec) is that azel targets
fakes it with astrometric (ra, dec), thereby introducing an error
when comparing any target with an azel target (a very common use case).

Reviewer: @LauraRichter 
