### PR TITLE
Fix package import with missing pkg_resources

### DIFF
--- a/katpoint/__init__.py
+++ b/katpoint/__init__.py
@@ -60,6 +60,7 @@ _no_config_handler.addFilter(_NoConfigFilter())
 logger = _logging.getLogger(__name__)
 logger.addHandler(_no_config_handler)
 
+# Attempt to determine installed package version
 try:
     import pkg_resources as _pkg_resources
 except ImportError:
@@ -71,5 +72,6 @@ else:
         # a .index method.
         ver = list(dist.parsed_version)
         __version__ = "r%d" % int(ver[ver.index("*r") + 1])
+        del dist, ver
     except (_pkg_resources.DistributionNotFound, ValueError, IndexError, TypeError):
         __version__ = "unknown"


### PR DESCRIPTION
If there is no pkg_resources, handle the ImportError but don't then
also look for a pkg_resources exception...
