### PR TITLE
Allow targets to be specified with any epoch.

### DIFF
--- a/katpoint/target.py
+++ b/katpoint/target.py
@@ -1,6 +1,7 @@
 """Target object used for pointing and flux density calculation."""
 
 import numpy as np
+import re
 import ephem
 
 from .timestamp import Timestamp
@@ -851,13 +852,18 @@ def construct_target_params(description):
             body.name = preferred_name
         else:
             body.name = "Ra: %s Dec: %s" % (ra, dec)
-        # Extract epoch info from tags
+        # Extract epoch info from tags default to ephem.J2000
         if ('B1900' in tags) or ('b1900' in tags):
             body._epoch = ephem.B1900
         elif ('B1950' in tags) or ('b1950' in tags):
             body._epoch = ephem.B1950
         else:
-            body._epoch = ephem.J2000
+            #Search for a well formed decimal number
+            epoch_re = re.compile('^(\d+(?:\.\d+)?)$')
+            epoch = [epoch_re.match(tag).group() for tag in tags if epoch_re.match(tag)]
+            #epoch will be an empty list if no decimal number is found
+            epoch = epoch[0] if epoch else ephem.J2000
+            body._epoch = epoch
         body._ra = ra
         body._dec = dec
 
@@ -872,7 +878,18 @@ def construct_target_params(description):
             body.name = preferred_name
         else:
             body.name = "Galactic l: %.4f b: %.4f" % (l, b)
-        body._epoch = ephem.J2000
+        # Extract epoch info from tags default to ephem.J2000
+        if ('B1900' in tags) or ('b1900' in tags):
+            body._epoch = ephem.B1900
+        elif ('B1950' in tags) or ('b1950' in tags):
+            body._epoch = ephem.B1950
+        else:
+            #Search for a well formed number (with optional decimal point)
+            decimal_re = re.compile('^(\d+(?:\.\d+)?)$')
+            epoch = [decimal_re.match(tag).group() for tag in tags if decimal_re.match(tag)]
+            #epoch will be an empty list if no decimal number is found
+            epoch = epoch[0] if epoch else ephem.J2000
+            body._epoch = epoch
         body._ra = ra
         body._dec = dec
 
@@ -972,11 +989,11 @@ def construct_azel_target(az, el):
 #--- FUNCTION :  construct_radec_target
 #--------------------------------------------------------------------------------------------------
 
-def construct_radec_target(ra, dec):
+def construct_radec_target(ra, dec, epoch=ephem.J2000):
     """Convenience function to create unnamed fixed target (*radec* body type).
 
     The input parameters will also accept :class:`ephem.Angle` objects, as these
-    are floats in radians internally. The epoch is assumed to be J2000.
+    are floats in radians internally.
 
     Parameters
     ----------
@@ -986,6 +1003,8 @@ def construct_radec_target(ra, dec):
     dec : string or float
         Declination, either in 'D:M:S' or decimal degree string format, or as
         a float in radians
+    epoch : string or float or tuple or :class:`ephem.Date` object
+        The epoch of the position, in any format accepted by a call to ephem.Date() 
 
     Returns
     -------
@@ -1002,7 +1021,7 @@ def construct_radec_target(ra, dec):
             pass
     ra, dec = ephem.hours(ra), ephem.degrees(dec)
     body.name = "Ra: %s Dec: %s" % (ra, dec)
-    body._epoch = ephem.J2000
+    body._epoch = epoch
     body._ra = ra
     body._dec = dec
     return Target(body, 'radec')


### PR DESCRIPTION
When creating a target the epoch of the coordinates can be specified as a tag. 'B1900' or 'B1950' will use the inbuilt ephem dates for those epochs. Other epochs can be specified with a decimal string, specifying the Gregorian date of the epoch desired. These changes have been made for both 'radec' and 'gal' targets.

The construct_radec_target method now allows the user to specify the epoch of the coordinates as well, which can be in any format accepted by ephem.Date().

J2000 is the default epoch in all cases.

@ludwigschwardt Please have a look. I've assumed that any target tag that is a decimal number is specifying a coordinate epoch. This might be dangerous if tags that are numbers are intended for other purposes. What do you think?
