### PR TITLE
Alternative pip method to get installed katpoint version

### DIFF
--- a/katpoint/__init__.py
+++ b/katpoint/__init__.py
@@ -62,16 +62,14 @@ logger.addHandler(_no_config_handler)
 
 # Attempt to determine installed package version
 try:
-    import pkg_resources as _pkg_resources
+    import pip
 except ImportError:
     __version__ = "unknown"
 else:
     try:
-        dist = _pkg_resources.get_distribution("katpoint")
-        # ver needs to be a list since tuples in Python <= 2.5 don't have
-        # a .index method.
-        ver = list(dist.parsed_version)
-        __version__ = "r%d" % int(ver[ver.index("*r") + 1])
-        del dist, ver
-    except (_pkg_resources.DistributionNotFound, ValueError, IndexError, TypeError):
+        dist = next(d for d in pip.get_installed_distributions()
+                    if d.key == 'katpoint')
+        __version__ = dist.version
+        del dist
+    except StopIteration:
         __version__ = "unknown"


### PR DESCRIPTION
@ludwigschwardt:

Attempting to get rid of warning message:
`/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py:190: RuntimeWarning: You have iterated over the result of pkg_resources.parse_version. This is a legacy behavior which is inconsistent with the new version class introduced in setuptools 8.0. In most cases, conversion to a tuple is unnecessary. For comparison of versions, sort the Version instances directly. If you have another use case requiring the tuple, please file a bug with the setuptools project describing that need.`

Don't know if this 'attempt to determine installed package version' is still applicable OR if there is still need to support katpoint for Python <=2.5? If still required, here is an alternative suggestion to get rid of the above warning message.
