### PR TITLE
Add description property for DelayCorrection object

### DIFF
--- a/katpoint/delay.py
+++ b/katpoint/delay.py
@@ -285,3 +285,12 @@ class DelayCorrection(object):
         phase_polys = np.dstack((phase_corrections, phase_slopes)).squeeze()
         return (dict(zip(self.inputs, delay_polys)),
                 dict(zip(self.inputs, phase_polys)))
+
+    @property
+    def description(self):
+        """Concise string representation of delay correction object."""
+        lines = [self.ref_ant.description]
+        for ant in self.ants:
+            lines.append("{}, {}".format(ant.name, ant.delay_model.description))
+        lines.append("sky centre freq {}".format(self.sky_centre_freq))
+        return '\n'.join(lines)

--- a/katpoint/test/test_delay.py
+++ b/katpoint/test/test_delay.py
@@ -92,3 +92,20 @@ class TestDelayCorrection(unittest.TestCase):
         for n in range(max_size + 10):
             delay0, phase0 = self.delays.corrections(self.target1, self.ts + n)
         self.assertEqual(len(self.delays._cache), max_size, 'Delay cache grew past limit')
+
+    def test_description(self):
+        """Test description property."""
+        description = self.delays.description
+        num_lines_expected = len(self.delays.ants) + 2  # (2 = 1 x ref + 1 x freq)
+        num_lines = len(description.splitlines())
+        self.assertEqual(num_lines_expected, num_lines)
+        for item in ['A1', 'A2', 'A3', 'sky centre freq']:
+            self.assertIn(item, description)
+        # check that description doesn't break with no antennas
+        no_ants_delays = katpoint.DelayCorrection([], self.ant1, 1.285e9)
+        description = no_ants_delays.description
+        num_lines_expected = 0 + 2
+        num_lines = len(description.splitlines())
+        self.assertEqual(num_lines_expected, num_lines)
+        for item in ['A1', 'sky centre freq']:
+            self.assertIn(item, description)


### PR DESCRIPTION
In CAM we want to use the description to populate a sensor on the correlator beamformer proxy, so that users can easily verify that the correct delay models are in use.  Here is an example, after this change:

![image](https://user-images.githubusercontent.com/20420754/28203843-acb5cdc6-687b-11e7-96af-b5278282b74a.png)

This description isn't quite as complete as the other models, since the `DelayCorrection` object contains many models.  Printing all of their parameters as part of the description would be overly verbose.  E.g. the reference observer location would be repeated for each antenna.  The compromise is to print the minimum information related to the delays. It is printed over multiple lines
to make it more readable.  Note that the option to instantiate a `DelayCorrection` object from the text description is not implemented, unlike the model classes.