### PR TITLE
Modernise tab completion (take 2)

### DIFF
--- a/katpoint/__init__.py
+++ b/katpoint/__init__.py
@@ -32,7 +32,7 @@ from .target import Target, construct_azel_target, construct_radec_target
 from .antenna import Antenna
 from .timestamp import Timestamp
 from .flux import FluxDensityModel
-from .catalogue import Catalogue, specials, _catalogue_completer
+from .catalogue import Catalogue, specials
 from .ephem_extra import lightspeed, rad2deg, deg2rad, wrap_angle, is_iterable
 from .conversion import (lla_to_ecef, ecef_to_lla, enu_to_ecef, ecef_to_enu,
                          azel_to_enu, enu_to_azel, hadec_to_enu, enu_to_xyz)
@@ -54,17 +54,6 @@ try:
         conversion, projection, pointing, refraction, delay
 except NameError:
     pass
-
-# Attempt to register custom IPython tab completer for catalogue name lookups (only when run from IPython shell)
-try:
-    # IPython 0.11 and above
-    _ip = get_ipython()
-except NameError:
-    # IPython 0.10 and below (or normal Python shell)
-    _ip = __builtins__.get('__IPYTHON__')
-if hasattr(_ip, 'set_hook'):
-    _ip.set_hook('complete_command', _catalogue_completer, re_key=r"(?:.*\=)?(.+?)\[")
-
 
 # Setup library logger and add a print-like handler used when no logging is configured
 class _NoConfigFilter(_logging.Filter):

--- a/katpoint/test/test_catalogue.py
+++ b/katpoint/test/test_catalogue.py
@@ -122,17 +122,3 @@ class TestCatalogueFilterSort(unittest.TestCase):
         cat.antenna = self.antenna
         cat.flux_freq_MHz = 1.5
         cat.visibility_list(timestamp=self.timestamp)
-
-    def test_completer(self):
-        """Test IPython tab completer."""
-        # pylint: disable-msg=W0201,W0612,R0903
-        cat = katpoint.Catalogue(add_stars=True)
-        # Set up dummy object containing user namespace and line to be completed
-        class Dummy(object):
-            pass
-        event = Dummy()
-        event.shell = Dummy()
-        event.shell.user_ns = locals()
-        event.line = "t = cat['Rasal"
-        names = katpoint._catalogue_completer(event, event)
-        self.assertEqual(names, ['Rasalgethi', 'Rasalhague'], 'Tab completer failed')


### PR DESCRIPTION
Since IPython 5.0 (PR ipython/ipython#9289 specifically) the customisation of dict key lookups has been considerably simplified by adding a specific method (`_ipython_key_completions_`) to your object. Strip out all the old tab completion machinery as a result.

Unfortunately the rest of the IPython machinery is still a bit clunky and the default completions now include all known tokens with that prefix, not only the ones returned by `_ipython_key_completions_`. This can be fixed by monkeypatching IPython in one of its startup files (ask the author).

This is the second attempt at PR #33.