### PR TITLE
Prepare for v0.9

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,13 @@
 History
 =======
 
+0.9 (2019-10-02)
+----------------
+* Add Antenna.reference_antenna utility function (#51)
+* Vectorise Target.uvw (#49)
+* Improve precision of flux model description string (#52)
+* Produce documentation on readthedocs.org (#48)
+
 0.8 (2019-02-12)
 ----------------
 * Improve UVW coordinates by using local and not global North (#46)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,10 +3,11 @@ History
 
 0.9 (2019-10-02)
 ----------------
-* Add Antenna.reference_antenna utility function (#51)
+* Add Antenna.array_reference_antenna utility function (#51)
 * Vectorise Target.uvw (#49)
 * Improve precision of flux model description string (#52)
 * Produce documentation on readthedocs.org (#48)
+* Add script that converts PSRCAT database into Catalogue (#16)
 
 0.8 (2019-02-12)
 ----------------


### PR DESCRIPTION
This addresses JIRA ticket SR-1619.

This is mostly for the `array_reference_antenna` utility function needed by the imminent katdal v0.14 release.