### PR TITLE
allow out of range values

### DIFF
--- a/katpoint/projection.py
+++ b/katpoint/projection.py
@@ -136,8 +136,9 @@ import numpy as np
 
 def sphere_to_ortho(az0, el0, az, el):
     """Do calculations common to all zenithal/azimuthal projections."""
-    if np.any(np.abs(el0) > np.pi / 2.0) or np.any(np.abs(el) > np.pi / 2.0):
-        raise ValueError('Elevation angle outside range of +- pi/2 radians')
+    if False:
+        if np.any(np.abs(el0) > np.pi / 2.0) or np.any(np.abs(el) > np.pi / 2.0):
+            raise ValueError('Elevation angle outside range of +- pi/2 radians')
     sin_el, cos_el, sin_el0, cos_el0 = np.sin(el), np.cos(el), np.sin(el0), np.cos(el0)
     # Keep azimuth delta between -pi and pi - probably unnecessary, but the only normalisation of az inputs
     delta_az = (az - az0 + np.pi) % (2.0 * np.pi) - np.pi


### PR DESCRIPTION
This section of code raises an exception in katdal, for some of my datasets where slewing occurs from far away from the target. It is understood that the slew data will not be valid, and alas, is not used. However katdal crashes even if I explicitly select out the slew parts of the data before I try to access the coordinates. Disappointingly katpoint tries to compute the transform for all coordinates in the file and then raises an exception if a coordinate exists that is out of range anywhere in the file. By commenting this out the valid data remains valid, and invalid data is undefined, which is slightly better than bombing out if any values in the file is out of range.

I need this fix to be made, as it has been years since my original request about this, and it is too cumbersome to keep on making my own versions of katpoint, and installing it on numerous servers, everytime there is a critical update to katdal.

