### PR TITLE
Use python2 legacy branches of katsdpdockerbase/katsdpjenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!groovy
 
-@Library('katsdpjenkins') _
+@Library('katsdpjenkins@python2') _
 katsdp.killOldJobs()
-katsdp.standardBuild(python3: true)
+katsdp.setDependencies(['ska-sa/katsdpdockerbase/python2'])
+katsdp.standardBuild(python3: true, katsdpdockerbase_ref: 'python2')
 katsdp.mail('ludwig@ska.ac.za')


### PR DESCRIPTION
Because they're going to move to Python 3 only.