### PR TITLE
Update scripts to use Astropy's VOTable

### DIFF
--- a/scripts/kuehr1Jy_sources.py
+++ b/scripts/kuehr1Jy_sources.py
@@ -53,26 +53,26 @@ import numpy as np
 import matplotlib.pyplot as plt
 import katpoint
 
-from vo.table import parse_single_table
+from astropy.table import Table
 
-# Load tables in one shot (don't be pedantic, as the VizieR VOTables contain a deprecated DEFINITIONS element)
-table = parse_single_table("kuehr1Jy.vot", pedantic=False)
-flux_table = parse_single_table("kuehr1Jy_flux.vot", pedantic=False)
+# Load tables in one shot (don't verify, as the VizieR VOTables contain a deprecated DEFINITIONS element)
+table = Table.read('kuehr1Jy.vot')
+flux_table = Table.read('kuehr1Jy_flux.vot')
 src_strings = []
-plot_freqs = [flux_table.array['Freq'].min(), flux_table.array['Freq'].max()]
+plot_freqs = [flux_table['Freq'].min(), flux_table['Freq'].max()]
 test_log_freq = np.linspace(np.log10(plot_freqs[0]), np.log10(plot_freqs[1]), 200)
 plot_rows = 8
 plots_per_fig = plot_rows * plot_rows
 
 # Iterate through sources
-for src in table.array:
+for src in table:
     names = '1Jy ' + src['_1Jy']
     if len(src['_3C']) > 0:
         names += ' | *' + src['_3C']
     ra, dec = katpoint.deg2rad(src['_RAJ2000']), katpoint.deg2rad(src['_DEJ2000'])
     tags_ra_dec = katpoint.construct_radec_target(ra, dec).add_tags('J2000').description
     # Extract flux data for the current source from flux table
-    flux = flux_table.array[flux_table.array['_1Jy'] == src['_1Jy']]
+    flux = flux_table[flux_table['_1Jy'] == src['_1Jy']]
     # Determine widest possible frequency range where flux is defined (ignore internal gaps in this range)
     # For better or worse, extend range to at least KAT7 frequency band (also handles empty frequency lists)
     flux_freqs = flux['Freq'].tolist() + [800.0, 2400.0]

--- a/scripts/pkscat90_sources.py
+++ b/scripts/pkscat90_sources.py
@@ -45,7 +45,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 import katpoint
-from vo.table import parse_single_table
+from astropy.table import Table
 
 
 # For each flux field in table, specify the name, centre frequency and start frequency (in MHz)
@@ -55,17 +55,17 @@ start = [20.0, 100.0, 200.0, 400.0, 750.0, 1500.0, 3000.0, 6000.0, 12000.0, 3000
 # List of anomalous flux fields that will be edited out for the purpose of fitting
 anomalies = {'J0108+1320': 6, 'J0541-0154': 2, 'J2253+1608': 6}
 
-# Load main table in one shot (don't be pedantic, as the VizieR VOTables contain a deprecated DEFINITIONS element)
-table = parse_single_table("pkscat90_S1410_min_10Jy.vot", pedantic=False)
+# Load main table in one shot (don't verify, as the VizieR VOTables contain a deprecated DEFINITIONS element)
+table = Table.read('pkscat90_S1410_min_10Jy.vot')
 
 # Fit all sources onto one figure
 plt.figure(1)
 plt.clf()
-plot_rows = int(np.ceil(np.sqrt(table.nrows)))
+plot_rows = int(np.ceil(np.sqrt(len(table))))
 src_strings = []
 
 # Iterate through sources
-for n, src in enumerate(table.array):
+for n, src in enumerate(table):
     names = src['Jname']
     if len(src['Alias']) > 0:
         names += ' | *' + src['Alias']

--- a/scripts/tabara_sources.py
+++ b/scripts/tabara_sources.py
@@ -54,11 +54,11 @@ import numpy as np
 from scikits.fitting import PiecewisePolynomial1DFit
 import katpoint
 
-from vo.table import parse_single_table
+from astropy.table import Table
 
-# Load tables in one shot (don't be pedantic, as the VizieR VOTables contain a deprecated DEFINITIONS element)
-table = parse_single_table("tabara.vot", pedantic=False)
-pol_table = parse_single_table("tabara_pol.vot", pedantic=False)
+# Load tables in one shot (don't verify, as the VizieR VOTables contain a deprecated DEFINITIONS element)
+table = Table.read('tabara.vot')
+pol_table = Table.read('tabara_pol.vot')
 # Use Kuehr 1Jy catalogue to provide flux density models
 flux_cat = katpoint.Catalogue(open('kuehr1Jy_source_list.csv'))
 # Use ATCA calibrator list to provide positions (and as a first-level check of source structure)
@@ -90,7 +90,7 @@ polflux_limit = 0.2
 
 # Iterate through sources
 src_strings = []
-for src in table.array:
+for src in table:
     # Select sources based on various criteria
     if src['S6cm'] < flux_limit:
         print('%s skipped: flux @ 6cm: %.2f < %.2f' % (src['Name'], src['S6cm'], flux_limit))
@@ -123,7 +123,7 @@ for src in table.array:
         (katpoint.deg2rad(src['_RAJ2000']), katpoint.deg2rad(src['_DEJ2000']))
     tags_ra_dec = katpoint.construct_radec_target(ra, dec).add_tags('J2000 ' + src['Type']).description
     # Extract polarisation data for the current source from pol table
-    pol_data = pol_table.array[pol_table.array['Name'] == src['Name']]
+    pol_data = pol_table[pol_table['Name'] == src['Name']]
     pol_freqs_MHz = katpoint.lightspeed / (0.01 * pol_data['lambda']) / 1e6
     pol_percent = pol_data['Pol']
     # Remove duplicate frequencies and fit linear interpolator to data as function of frequency


### PR DESCRIPTION
These old catalogue construction scripts still depended on the `vo` package, which has now been subsumed into Astropy. Update them to use the generic `astropy.table` instead.

This is a small update triggered by my need to find polarised sources. I don't think anyone else has noticed the rot :-)
