### PR TITLE
SR-1511: Handle out-of-range projection inputs

### DIFF
--- a/katpoint/__init__.py
+++ b/katpoint/__init__.py
@@ -40,7 +40,7 @@ from .catalogue import Catalogue, specials
 from .ephem_extra import lightspeed, rad2deg, deg2rad, wrap_angle, is_iterable
 from .conversion import (lla_to_ecef, ecef_to_lla, enu_to_ecef, ecef_to_enu,
                          azel_to_enu, enu_to_azel, hadec_to_enu, enu_to_xyz)
-from .projection import sphere_to_plane, plane_to_sphere, OutOfRange, OutOfRangeError
+from .projection import sphere_to_plane, plane_to_sphere
 from .model import Parameter, Model, BadModelFile
 from .pointing import PointingModel
 from .refraction import RefractionCorrection
@@ -50,11 +50,11 @@ from .delay import DelayModel, DelayCorrection
 # If the module is reloaded, this will fail - ignore the resulting NameError
 try:
     _target, _antenna, _timestamp, _flux, _catalogue, _ephem_extra, \
-        _conversion, _projection, _pointing, _refraction, _delay = \
+        _conversion, _pointing, _refraction, _delay = \
         target, antenna, timestamp, flux, catalogue, ephem_extra, \
-        conversion, projection, pointing, refraction, delay
+        conversion, pointing, refraction, delay
     del target, antenna, timestamp, flux, catalogue, ephem_extra, \
-        conversion, projection, pointing, refraction, delay
+        conversion, pointing, refraction, delay
 except NameError:
     pass
 

--- a/katpoint/__init__.py
+++ b/katpoint/__init__.py
@@ -40,7 +40,7 @@ from .catalogue import Catalogue, specials
 from .ephem_extra import lightspeed, rad2deg, deg2rad, wrap_angle, is_iterable
 from .conversion import (lla_to_ecef, ecef_to_lla, enu_to_ecef, ecef_to_enu,
                          azel_to_enu, enu_to_azel, hadec_to_enu, enu_to_xyz)
-from .projection import sphere_to_plane, plane_to_sphere
+from .projection import sphere_to_plane, plane_to_sphere, OutOfRange, OutOfRangeError
 from .model import Parameter, Model, BadModelFile
 from .pointing import PointingModel
 from .refraction import RefractionCorrection

--- a/katpoint/projection.py
+++ b/katpoint/projection.py
@@ -355,6 +355,8 @@ def sphere_to_ortho(az0, el0, az, el, min_cos_theta=None):
         check = ('Target point more than {} pi radians away from '
                  'reference point'.format(np.arccos(min_cos_theta) / np.pi))
         cos_theta = treat_out_of_range_values(cos_theta, check, lower=min_cos_theta)
+        # Adjust radius of (x, y) to be commensurate with potentially clipped cos(theta),
+        # and also propagate any NaNs in cos(theta) to (x, y) to complete out-of-range treatment
         sin_theta = np.sqrt(1.0 - cos_theta * cos_theta)
         ortho_x, ortho_y = safe_scale(ortho_x, ortho_y, new_radius=sin_theta)
     return ortho_x, ortho_y, cos_theta
@@ -518,7 +520,7 @@ def sphere_to_plane_tan(az0, el0, az, el):
         If an elevation is out of range or target is too far from reference,
         and out-of-range treatment is 'raise'
     """
-    # Angular separation theta must be strictly < 90 degrees - pick 1e-6 radians less
+    # Angular separation theta must be strictly < pi/2 radians - pick 1e-6 radians less
     ortho_x, ortho_y, cos_theta = sphere_to_ortho(az0, el0, az, el, min_cos_theta=1e-6)
     # x = tan(theta) * sin(phi), y = tan(theta) * cos(phi)
     return ortho_x / cos_theta, ortho_y / cos_theta
@@ -702,7 +704,7 @@ def sphere_to_plane_stg(az0, el0, az, el):
         If an elevation is out of range or target point opposite to reference,
         and out-of-range treatment is 'raise'
     """
-    # Angular separation theta must be strictly < 180 degrees - pick 1e-5 radians less
+    # Angular separation theta must be strictly < pi radians - pick 4.5e-3 radians less
     ortho_x, ortho_y, cos_theta = sphere_to_ortho(az0, el0, az, el, min_cos_theta=1e-5 - 1)
     den = 1.0 + cos_theta
     # x = 2 sin(theta) sin(phi) / (1 + cos(theta))

--- a/katpoint/projection.py
+++ b/katpoint/projection.py
@@ -238,7 +238,22 @@ class OutOfRange(object):
 
 
 def safe_scale(x, y, new_radius):
-    """"""
+    """Scale the length of the 2D (x, y) vector to a new radius in a safe way.
+
+    This handles both scalars and arrays, and maps the origin to (new_radius, 0).
+
+    Parameters
+    ----------
+    x, y : float or array
+        Coordinates of 2D vector(s) (unchanged by this function)
+    new_radius : float or array
+        Desired length of output vector(s)
+
+    Returns
+    -------
+    out_x, out_y : float or array
+        Coordinates of 2D vector(s) guaranteed to have length `new_radius`
+    """
     x = np.asarray(x).copy()
     y = np.asarray(y).copy()
     new_radius = np.asarray(new_radius)
@@ -257,7 +272,36 @@ def safe_scale(x, y, new_radius):
 
 
 def sphere_to_ortho(az0, el0, az, el, min_cos_theta=None):
-    """Do calculations common to all zenithal/azimuthal projections."""
+    """Do calculations common to all zenithal/azimuthal projections.
+
+    This does a basic orthographic (SIN) projection and also returns the angular
+    separation / native latitude `theta` in cosine form, which can be used to
+    construct many other projections. The angular separation is optionally
+    checked against a projection-specific limit, and the (x, y) outputs are
+    treated accordingly.
+
+    Parameters
+    ----------
+    az0 : float or array
+        Azimuth / right ascension / longitude of reference point(s), in radians
+    el0 : float or array
+        Elevation / declination / latitude of reference point(s), in radians
+    az : float or array
+        Azimuth / right ascension / longitude of target point(s), in radians
+    el : float or array
+        Elevation / declination / latitude of target point(s), in radians
+    min_cos_theta : float, optional
+        Limit on angular separation of target and reference, used to clip (x, y)
+
+    Returns
+    -------
+    ortho_x : float or array
+        Azimuth-like coordinate(s) on plane (equivalent to l), in radians
+    ortho_y : float or array
+        Elevation-like coordinate(s) on plane (equivalent to m), in radians
+    cos_theta : float or array
+        Angular separation of target and reference points, expressed as cosine
+    """
     # Ensure that elevation angles are in valid range if they are finite numbers
     check = 'Elevation angle outside range of +- pi/2 radians'
     el0 = OutOfRange.treat(el0, check, lower=-np.pi / 2.0, upper=np.pi / 2.0)

--- a/katpoint/test/aips_projection/build_module.sh
+++ b/katpoint/test/aips_projection/build_module.sh
@@ -26,14 +26,14 @@
 #
 
 # Obtain AIPS source files (keep URL up to date!)
-aips_src=ftp.aoc.nrao.edu::31DEC16
+aips_src=ftp.aoc.nrao.edu::31DEC20
 rsync -auvz --timeout=120 --files-from=aips_files.lst --no-relative $aips_src .
 for f in *.FOR; do mv $f ${f/.FOR/.F}; done
 # Add f2py icing and comment out troublesome AIPS calls
 patch -p0 < aips_files.patch
 
 # On some systems the Python version is appended to f2py executable name (probably to avoid clashes)
-pyver=`python -c "import sys; print('%d.%d' % sys.version_info[:2])"`
+pyver=`python3 -c "import sys; print('%d.%d' % sys.version_info[:2])"`
 f2py_exe='f2py'$pyver
 if ! which $f2py_exe ; then
   f2py_exe='f2py'

--- a/katpoint/test/test_delay.py
+++ b/katpoint/test/test_delay.py
@@ -126,10 +126,10 @@ class TestDelayCorrection(unittest.TestCase):
         delay1, phase1 = self.delays.corrections(target3, self.ts,
                                                  self.ts + 1.0, offset)
         # Conspire to return to special target1
-        self.assertEqual(delay0['A2h'], extra_delay, 'Delay for ant2h should be zero')
-        self.assertEqual(delay0['A2v'], extra_delay, 'Delay for ant2v should be zero')
-        self.assertEqual(delay1['A2h'][0], extra_delay, 'Delay for ant2h should be zero')
-        self.assertEqual(delay1['A2v'][0], extra_delay, 'Delay for ant2v should be zero')
+        np.testing.assert_almost_equal(delay0['A2h'], extra_delay, decimal=15)
+        np.testing.assert_almost_equal(delay0['A2v'], extra_delay, decimal=15)
+        np.testing.assert_almost_equal(delay1['A2h'][0], extra_delay, decimal=15)
+        np.testing.assert_almost_equal(delay1['A2v'][0], extra_delay, decimal=15)
         self.assertEqual(delay1['A2h'][1], 0.0, 'Delay rate for ant2h should be zero')
         self.assertEqual(delay1['A2v'][1], 0.0, 'Delay rate for ant2v should be zero')
         # Now try (ra, dec) coordinate system

--- a/katpoint/test/test_projection.py
+++ b/katpoint/test/test_projection.py
@@ -158,9 +158,6 @@ class TestProjectionSIN(unittest.TestCase):
         np.testing.assert_almost_equal(xy, [1.0, 0.0], decimal=12)
         xy = np.array(self.sphere_to_plane(0.0, np.pi / 2.0, -np.pi / 2.0, 0.0))
         np.testing.assert_almost_equal(xy, [-1.0, 0.0], decimal=12)
-        # Points outside allowed domain on sphere
-        self.assertRaises(ValueError, self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
-        self.assertRaises(ValueError, self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
 
         # PLANE TO SPHERE
         # Origin
@@ -184,9 +181,42 @@ class TestProjectionSIN(unittest.TestCase):
         assert_angles_almost_equal(ae, [0.0, 0.0], decimal=12)
         ae = np.array(self.plane_to_sphere(0.0,  -np.pi / 2.0, 0.0, -1.0))
         assert_angles_almost_equal(ae, [np.pi, 0.0], decimal=12)
+
+    def test_out_of_range_cases(self):
+        """SIN projection: test out-of-range cases."""
+        # SPHERE TO PLANE
+        # Points outside allowed domain on sphere
+        with OutOfRange.set_treatment('raise'):
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, np.pi, 0.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
+        with OutOfRange.set_treatment('clip'):
+            xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_almost_equal(xy, [0.0, -1.0], decimal=12)
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
+            np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=12)
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
+            np.testing.assert_almost_equal(xy, [0.0, 1.0], decimal=12)
+
+        # PLANE TO SPHERE
         # Points outside allowed domain in plane
-        self.assertRaises(ValueError, self.plane_to_sphere, 0.0, 0.0, 2.0, 0.0)
-        self.assertRaises(ValueError, self.plane_to_sphere, 0.0, 0.0, 0.0, 2.0)
+        with OutOfRange.set_treatment('raise'):
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, np.pi, 0.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, 0.0, 2.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, 0.0, 0.0, 2.0)
+        with OutOfRange.set_treatment('clip'):
+            ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
+            assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 2.0, 0.0))
+            assert_angles_almost_equal(ae, [np.pi / 2.0, 0.0], decimal=12)
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 2.0))
+            assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
 
 
 class TestProjectionTAN(unittest.TestCase):
@@ -264,9 +294,6 @@ class TestProjectionTAN(unittest.TestCase):
         np.testing.assert_almost_equal(xy, [1.0, 0.0], decimal=12)
         xy = np.array(self.sphere_to_plane(0.0, np.pi / 2.0, -np.pi / 2.0, np.pi / 4.0))
         np.testing.assert_almost_equal(xy, [-1.0, 0.0], decimal=12)
-        # Points outside allowed domain on sphere
-        self.assertRaises(ValueError, self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
-        self.assertRaises(ValueError, self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
 
         # PLANE TO SPHERE
         # Origin
@@ -290,6 +317,34 @@ class TestProjectionTAN(unittest.TestCase):
         assert_angles_almost_equal(ae, [0.0, -np.pi / 4.0], decimal=12)
         ae = np.array(self.plane_to_sphere(0.0,  -np.pi / 2.0, 0.0, -1.0))
         assert_angles_almost_equal(ae, [np.pi, -np.pi / 4.0], decimal=12)
+
+    def test_out_of_range_cases(self):
+        """TAN projection: test out-of-range cases."""
+        # SPHERE TO PLANE
+        # Points outside allowed domain on sphere
+        with OutOfRange.set_treatment('raise'):
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, np.pi, 0.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
+        with OutOfRange.set_treatment('clip'):
+            xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_almost_equal(xy, [0.0, -1e5], decimal=11)
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
+            np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=11)
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
+            np.testing.assert_almost_equal(xy, [0.0, 1e5], decimal=11)
+
+        # PLANE TO SPHERE
+        # Points outside allowed domain in plane
+        with OutOfRange.set_treatment('raise'):
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, np.pi, 0.0, 0.0)
+        with OutOfRange.set_treatment('clip'):
+            ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
+            assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
 
 
 class TestProjectionARC(unittest.TestCase):
@@ -366,8 +421,6 @@ class TestProjectionARC(unittest.TestCase):
         # Point diametrically opposite the reference point on sphere
         xy = np.array(self.sphere_to_plane(np.pi, 0.0, 0.0, 0.0))
         np.testing.assert_almost_equal(np.abs(xy), [np.pi, 0.0], decimal=12)
-        # Points outside allowed domain on sphere
-        self.assertRaises(ValueError, self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
 
         # PLANE TO SPHERE
         # Origin
@@ -400,9 +453,38 @@ class TestProjectionARC(unittest.TestCase):
         assert_angles_almost_equal(ae, [0.0, 0.0], decimal=12)
         ae = np.array(self.plane_to_sphere(0.0,  -np.pi / 2.0, 0.0, -np.pi / 2.0))
         assert_angles_almost_equal(ae, [np.pi, 0.0], decimal=12)
+
+    def test_out_of_range_cases(self):
+        """ARC projection: test out-of-range cases."""
+        # SPHERE TO PLANE
+        # Points outside allowed domain on sphere
+        with OutOfRange.set_treatment('raise'):
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, np.pi, 0.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
+        with OutOfRange.set_treatment('clip'):
+            xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_almost_equal(xy, [0.0, -np.pi / 2.0], decimal=12)
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
+            np.testing.assert_almost_equal(xy, [0.0, np.pi / 2.0], decimal=12)
+
+        # PLANE TO SPHERE
         # Points outside allowed domain in plane
-        self.assertRaises(ValueError, self.plane_to_sphere, 0.0, 0.0, 4.0, 0.0)
-        self.assertRaises(ValueError, self.plane_to_sphere, 0.0, 0.0, 0.0, 4.0)
+        with OutOfRange.set_treatment('raise'):
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, np.pi, 0.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, 0.0, 4.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, 0.0, 0.0, 4.0)
+        with OutOfRange.set_treatment('clip'):
+            ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
+            assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 4.0, 0.0))
+            assert_angles_almost_equal(ae, [np.pi, 0.0], decimal=12)
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 4.0))
+            assert_angles_almost_equal(ae, [np.pi, 0.0], decimal=12)
 
 
 class TestProjectionSTG(unittest.TestCase):
@@ -478,9 +560,6 @@ class TestProjectionSTG(unittest.TestCase):
         np.testing.assert_almost_equal(xy, [2.0, 0.0], decimal=12)
         xy = np.array(self.sphere_to_plane(0.0, np.pi / 2.0, -np.pi / 2.0, 0.0))
         np.testing.assert_almost_equal(xy, [-2.0, 0.0], decimal=12)
-        # Points outside allowed domain on sphere
-        self.assertRaises(ValueError, self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
-        self.assertRaises(ValueError, self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
 
         # PLANE TO SPHERE
         # Origin
@@ -504,6 +583,34 @@ class TestProjectionSTG(unittest.TestCase):
         assert_angles_almost_equal(ae, [0.0, 0.0], decimal=12)
         ae = np.array(self.plane_to_sphere(0.0,  -np.pi / 2.0, 0.0, -2.0))
         assert_angles_almost_equal(ae, [np.pi, 0.0], decimal=12)
+
+    def test_out_of_range_cases(self):
+        """STG projection: test out-of-range cases."""
+        # SPHERE TO PLANE
+        # Points outside allowed domain on sphere
+        with OutOfRange.set_treatment('raise'):
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, np.pi, 0.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
+        with OutOfRange.set_treatment('clip'):
+            xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_almost_equal(xy, [0.0, -2.0], decimal=12)
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
+            np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=10)
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
+            np.testing.assert_almost_equal(xy, [0.0, 2.0], decimal=12)
+
+        # PLANE TO SPHERE
+        # Points outside allowed domain in plane
+        with OutOfRange.set_treatment('raise'):
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, np.pi, 0.0, 0.0)
+        with OutOfRange.set_treatment('clip'):
+            ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
+            assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
 
 
 class TestProjectionCAR(unittest.TestCase):
@@ -610,9 +717,6 @@ class TestProjectionSSN(unittest.TestCase):
         np.testing.assert_almost_equal(xy, [0.0, 1.0], decimal=12)
         xy = np.array(self.sphere_to_plane(0.0, np.pi / 2.0, -np.pi / 2.0, 0.0))
         np.testing.assert_almost_equal(xy, [0.0, 1.0], decimal=12)
-        # Points outside allowed domain on sphere
-        self.assertRaises(ValueError, self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
-        self.assertRaises(ValueError, self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
 
         # PLANE TO SPHERE
         # Origin
@@ -637,6 +741,39 @@ class TestProjectionSSN(unittest.TestCase):
         assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
         ae = np.array(self.plane_to_sphere(0.0, -1.0, 0.0, np.cos(1.0)))
         assert_angles_almost_equal(ae, [0.0, -np.pi / 2.0], decimal=12)
+
+    def test_out_of_range_cases(self):
+        """SSN projection: test out-of-range cases."""
+        # SPHERE TO PLANE
+        # Points outside allowed domain on sphere
+        with OutOfRange.set_treatment('raise'):
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, np.pi, 0.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
+        with OutOfRange.set_treatment('clip'):
+            xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_almost_equal(xy, [0.0, 1.0], decimal=12)
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
+            np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=12)
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
+            np.testing.assert_almost_equal(xy, [0.0, -1.0], decimal=12)
+
+        # PLANE TO SPHERE
         # Points outside allowed domain in plane
-        self.assertRaises(ValueError, self.plane_to_sphere, 0.0, 0.0, 2.0, 0.0)
-        self.assertRaises(ValueError, self.plane_to_sphere, 0.0, 0.0, 0.0, 2.0)
+        with OutOfRange.set_treatment('raise'):
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, np.pi, 0.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, 0.0, 2.0, 0.0)
+            self.assertRaises(OutOfRangeError,
+                              self.plane_to_sphere, 0.0, 0.0, 0.0, 2.0)
+        with OutOfRange.set_treatment('clip'):
+            ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
+            assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 2.0, 0.0))
+            assert_angles_almost_equal(ae, [-np.pi / 2.0, 0.0], decimal=12)
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 2.0))
+            assert_angles_almost_equal(ae, [0.0, -np.pi / 2.0], decimal=12)

--- a/katpoint/test/test_projection.py
+++ b/katpoint/test/test_projection.py
@@ -126,17 +126,17 @@ class TestOutOfRangeTreatment(unittest.TestCase):
 class TestProjectionSIN(unittest.TestCase):
     """Test orthographic projection."""
     def setUp(self):
-        np.random.seed(42)
+        rs = np.random.RandomState(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['SIN']
         self.sphere_to_plane = katpoint.sphere_to_plane['SIN']
         N = 100
         max_theta = np.pi / 2.0
-        self.az0 = np.pi * (2.0 * np.random.rand(N) - 1.0)
+        self.az0 = np.pi * (2.0 * rs.rand(N) - 1.0)
         # Keep away from poles (leave them as corner cases)
-        self.el0 = 0.999 * np.pi * (np.random.rand(N) - 0.5)
+        self.el0 = 0.999 * np.pi * (rs.rand(N) - 0.5)
         # (x, y) points within unit circle
-        theta = max_theta * np.random.rand(N)
-        phi = 2 * np.pi * np.random.rand(N)
+        theta = max_theta * rs.rand(N)
+        phi = 2 * np.pi * rs.rand(N)
         self.x = np.sin(theta) * np.cos(phi)
         self.y = np.sin(theta) * np.sin(phi)
 
@@ -272,17 +272,17 @@ class TestProjectionSIN(unittest.TestCase):
 class TestProjectionTAN(unittest.TestCase):
     """Test gnomonic projection."""
     def setUp(self):
-        np.random.seed(42)
+        rs = np.random.RandomState(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['TAN']
         self.sphere_to_plane = katpoint.sphere_to_plane['TAN']
         N = 100
         # Stay away from edge of hemisphere
         max_theta = np.pi / 2.0 - 0.01
-        self.az0 = np.pi * (2.0 * np.random.rand(N) - 1.0)
+        self.az0 = np.pi * (2.0 * rs.rand(N) - 1.0)
         # Keep away from poles (leave them as corner cases)
-        self.el0 = 0.999 * np.pi * (np.random.rand(N) - 0.5)
-        theta = max_theta * np.random.rand(N)
-        phi = 2 * np.pi * np.random.rand(N)
+        self.el0 = 0.999 * np.pi * (rs.rand(N) - 0.5)
+        theta = max_theta * rs.rand(N)
+        phi = 2 * np.pi * rs.rand(N)
         # Perform inverse TAN mapping to spread out points on plane
         self.x = np.tan(theta) * np.cos(phi)
         self.y = np.tan(theta) * np.sin(phi)
@@ -411,18 +411,18 @@ class TestProjectionTAN(unittest.TestCase):
 class TestProjectionARC(unittest.TestCase):
     """Test zenithal equidistant projection."""
     def setUp(self):
-        np.random.seed(42)
+        rs = np.random.RandomState(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['ARC']
         self.sphere_to_plane = katpoint.sphere_to_plane['ARC']
         N = 100
         # Stay away from edge of circle
         max_theta = np.pi - 0.01
-        self.az0 = np.pi * (2.0 * np.random.rand(N) - 1.0)
+        self.az0 = np.pi * (2.0 * rs.rand(N) - 1.0)
         # Keep away from poles (leave them as corner cases)
-        self.el0 = 0.999 * np.pi * (np.random.rand(N) - 0.5)
+        self.el0 = 0.999 * np.pi * (rs.rand(N) - 0.5)
         # (x, y) points within circle of radius pi
-        theta = max_theta * np.random.rand(N)
-        phi = 2 * np.pi * np.random.rand(N)
+        theta = max_theta * rs.rand(N)
+        phi = 2 * np.pi * rs.rand(N)
         self.x = theta * np.cos(phi)
         self.y = theta * np.sin(phi)
 
@@ -564,19 +564,19 @@ class TestProjectionARC(unittest.TestCase):
 class TestProjectionSTG(unittest.TestCase):
     """Test stereographic projection."""
     def setUp(self):
-        np.random.seed(42)
+        rs = np.random.RandomState(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['STG']
         self.sphere_to_plane = katpoint.sphere_to_plane['STG']
         N = 100
         # Stay well away from point of projection
         max_theta = 0.8 * np.pi
-        self.az0 = np.pi * (2.0 * np.random.rand(N) - 1.0)
+        self.az0 = np.pi * (2.0 * rs.rand(N) - 1.0)
         # Keep away from poles (leave them as corner cases)
-        self.el0 = 0.999 * np.pi * (np.random.rand(N) - 0.5)
+        self.el0 = 0.999 * np.pi * (rs.rand(N) - 0.5)
         # Perform inverse STG mapping to spread out points on plane
-        theta = max_theta * np.random.rand(N)
+        theta = max_theta * rs.rand(N)
         r = 2.0 * np.sin(theta) / (1.0 + np.cos(theta))
-        phi = 2 * np.pi * np.random.rand(N)
+        phi = 2 * np.pi * rs.rand(N)
         self.x = r * np.cos(phi)
         self.y = r * np.sin(phi)
 
@@ -701,16 +701,16 @@ class TestProjectionSTG(unittest.TestCase):
 class TestProjectionCAR(unittest.TestCase):
     """Test plate carree projection."""
     def setUp(self):
-        np.random.seed(42)
+        rs = np.random.RandomState(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['CAR']
         self.sphere_to_plane = katpoint.sphere_to_plane['CAR']
         N = 100
         # Unrestricted (az0, el0) points on sphere
-        self.az0 = np.pi * (2.0 * np.random.rand(N) - 1.0)
-        self.el0 = np.pi * (np.random.rand(N) - 0.5)
+        self.az0 = np.pi * (2.0 * rs.rand(N) - 1.0)
+        self.el0 = np.pi * (rs.rand(N) - 0.5)
         # Unrestricted (x, y) points on corresponding plane
-        self.x = np.pi * (2.0 * np.random.rand(N) - 1.0)
-        self.y = np.pi * (np.random.rand(N) - 0.5)
+        self.x = np.pi * (2.0 * rs.rand(N) - 1.0)
+        self.y = np.pi * (rs.rand(N) - 0.5)
 
     def test_random_closure(self):
         """CAR projection: do random projections and check closure."""
@@ -743,22 +743,22 @@ def plane_to_sphere_original_ssn(target_az, target_el, ll, mm):
 class TestProjectionSSN(unittest.TestCase):
     """Test swapped orthographic projection."""
     def setUp(self):
-        np.random.seed(42)
+        rs = np.random.RandomState(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['SSN']
         self.sphere_to_plane = katpoint.sphere_to_plane['SSN']
         N = 100
-        self.az0 = np.pi * (2.0 * np.random.rand(N) - 1.0)
+        self.az0 = np.pi * (2.0 * rs.rand(N) - 1.0)
         # Keep away from poles (leave them as corner cases)
-        self.el0 = 0.999 * np.pi * (np.random.rand(N) - 0.5)
+        self.el0 = 0.999 * np.pi * (rs.rand(N) - 0.5)
         # (x, y) points within complicated SSN domain - clipped unit circle
         cos_el0 = np.cos(self.el0)
         # The x coordinate is bounded by +- cos(el0)
-        self.x = (2 * np.random.rand(N) - 1) * cos_el0
+        self.x = (2 * rs.rand(N) - 1) * cos_el0
         # The y coordinate ranges between two (semi-)circles centred on origin:
         # the unit circle on one side and circle of radius cos(el0) on other side
         y_offset = -np.sqrt(cos_el0 ** 2 - self.x ** 2)
         y_range = -y_offset + np.sqrt(1.0 - self.x ** 2)
-        self.y = (y_range * np.random.rand(N) + y_offset) * np.sign(self.el0)
+        self.y = (y_range * rs.rand(N) + y_offset) * np.sign(self.el0)
 
     def test_random_closure(self):
         """SSN projection: do random projections and check closure."""

--- a/katpoint/test/test_projection.py
+++ b/katpoint/test/test_projection.py
@@ -98,6 +98,27 @@ class TestOutOfRangeTreatment(unittest.TestCase):
             y = treat_out_of_range_values(x, 'Out of range', upper=1.1)
             np.testing.assert_array_equal(y, 1.1)
 
+    def test_scalar_vs_0d(self):
+        with out_of_range_context('clip'):
+            x = 2.0
+            y = treat_out_of_range_values(x, 'Out of range', upper=1.1)
+            assert np.isscalar(y)
+            x = np.array(2.0)
+            y = treat_out_of_range_values(x, 'Out of range', upper=1.1)
+            assert not np.isscalar(y)
+
+    def test_clipping_of_minor_outliers(self):
+        x = 1.0 + np.finfo(float).eps
+        with out_of_range_context('raise'):
+            y = treat_out_of_range_values(x, 'Should not trigger false alarm', upper=1.0)
+            assert y == 1.0
+        with out_of_range_context('nan'):
+            y = treat_out_of_range_values(x, 'Should not trigger false alarm', upper=1.0)
+            assert y == 1.0
+        with out_of_range_context('clip'):
+            y = treat_out_of_range_values(x, 'Should not trigger false alarm', upper=1.0)
+            assert y == 1.0
+
     def tearDown(self):
         set_out_of_range_treatment(self._old_treatment)
 

--- a/katpoint/test/test_projection.py
+++ b/katpoint/test/test_projection.py
@@ -59,6 +59,8 @@ class TestOutOfRangeTreatment(unittest.TestCase):
     def test_treatment_setup(self):
         OutOfRange.set_treatment('raise')
         self.assertEqual(OutOfRange.get_treatment(), 'raise')
+        OutOfRange.set_treatment('nan')
+        self.assertEqual(OutOfRange.get_treatment(), 'nan')
         OutOfRange.set_treatment('clip')
         self.assertEqual(OutOfRange.get_treatment(), 'clip')
         with self.assertRaises(ValueError):
@@ -74,6 +76,9 @@ class TestOutOfRangeTreatment(unittest.TestCase):
         with OutOfRange.set_treatment('raise'):
             with self.assertRaises(OutOfRangeError):
                 y = OutOfRange.treat(x, 'Out of range', lower=2.1)
+        with OutOfRange.set_treatment('nan'):
+            y = OutOfRange.treat(x, 'Out of range', lower=2.1)
+            np.testing.assert_array_equal(y, [np.nan, np.nan, 3.0, 4.0])
         with OutOfRange.set_treatment('clip'):
             y = OutOfRange.treat(x, 'Out of range', upper=1.1)
             np.testing.assert_array_equal(y, [1.0, 1.1, 1.1, 1.1])
@@ -85,6 +90,9 @@ class TestOutOfRangeTreatment(unittest.TestCase):
         with OutOfRange.set_treatment('raise'):
             with self.assertRaises(OutOfRangeError):
                 y = OutOfRange.treat(x, 'Out of range', lower=2.1)
+        with OutOfRange.set_treatment('nan'):
+            y = OutOfRange.treat(x, 'Out of range', lower=2.1)
+            np.testing.assert_array_equal(y, np.nan)
         with OutOfRange.set_treatment('clip'):
             y = OutOfRange.treat(x, 'Out of range', upper=1.1)
             np.testing.assert_array_equal(y, 1.1)
@@ -199,6 +207,13 @@ class TestProjectionSIN(unittest.TestCase):
                               self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
             self.assertRaises(OutOfRangeError,
                               self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
+        with OutOfRange.set_treatment('nan'):
+            xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
         with OutOfRange.set_treatment('clip'):
             xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
             np.testing.assert_almost_equal(xy, [0.0, -1.0], decimal=12)
@@ -216,6 +231,13 @@ class TestProjectionSIN(unittest.TestCase):
                               self.plane_to_sphere, 0.0, 0.0, 2.0, 0.0)
             self.assertRaises(OutOfRangeError,
                               self.plane_to_sphere, 0.0, 0.0, 0.0, 2.0)
+        with OutOfRange.set_treatment('nan'):
+            ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 2.0, 0.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 2.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
         with OutOfRange.set_treatment('clip'):
             ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
             assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
@@ -336,6 +358,13 @@ class TestProjectionTAN(unittest.TestCase):
                               self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
             self.assertRaises(OutOfRangeError,
                               self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
+        with OutOfRange.set_treatment('nan'):
+            xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
         with OutOfRange.set_treatment('clip'):
             xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
             np.testing.assert_almost_equal(xy, [0.0, -1e6], decimal=4)
@@ -349,6 +378,9 @@ class TestProjectionTAN(unittest.TestCase):
         with OutOfRange.set_treatment('raise'):
             self.assertRaises(OutOfRangeError,
                               self.plane_to_sphere, 0.0, np.pi, 0.0, 0.0)
+        with OutOfRange.set_treatment('nan'):
+            ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
         with OutOfRange.set_treatment('clip'):
             ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
             assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
@@ -471,6 +503,11 @@ class TestProjectionARC(unittest.TestCase):
                               self.sphere_to_plane, 0.0, np.pi, 0.0, 0.0)
             self.assertRaises(OutOfRangeError,
                               self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
+        with OutOfRange.set_treatment('nan'):
+            xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
         with OutOfRange.set_treatment('clip'):
             xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
             np.testing.assert_almost_equal(xy, [0.0, -np.pi / 2.0], decimal=12)
@@ -486,6 +523,13 @@ class TestProjectionARC(unittest.TestCase):
                               self.plane_to_sphere, 0.0, 0.0, 4.0, 0.0)
             self.assertRaises(OutOfRangeError,
                               self.plane_to_sphere, 0.0, 0.0, 0.0, 4.0)
+        with OutOfRange.set_treatment('nan'):
+            ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 4.0, 0.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 4.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
         with OutOfRange.set_treatment('clip'):
             ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
             assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
@@ -604,6 +648,13 @@ class TestProjectionSTG(unittest.TestCase):
                               self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
             self.assertRaises(OutOfRangeError,
                               self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
+        with OutOfRange.set_treatment('nan'):
+            xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
         with OutOfRange.set_treatment('clip'):
             xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
             np.testing.assert_almost_equal(xy, [0.0, -2.0], decimal=12)
@@ -617,6 +668,9 @@ class TestProjectionSTG(unittest.TestCase):
         with OutOfRange.set_treatment('raise'):
             self.assertRaises(OutOfRangeError,
                               self.plane_to_sphere, 0.0, np.pi, 0.0, 0.0)
+        with OutOfRange.set_treatment('nan'):
+            ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
         with OutOfRange.set_treatment('clip'):
             ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
             assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)
@@ -764,6 +818,13 @@ class TestProjectionSSN(unittest.TestCase):
                               self.sphere_to_plane, 0.0, 0.0, np.pi, 0.0)
             self.assertRaises(OutOfRangeError,
                               self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
+        with OutOfRange.set_treatment('nan'):
+            xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
+            xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
+            np.testing.assert_array_equal(xy, [np.nan, np.nan])
         with OutOfRange.set_treatment('clip'):
             xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
             np.testing.assert_almost_equal(xy, [0.0, 1.0], decimal=12)
@@ -781,6 +842,23 @@ class TestProjectionSSN(unittest.TestCase):
                               self.plane_to_sphere, 0.0, 0.0, 2.0, 0.0)
             self.assertRaises(OutOfRangeError,
                               self.plane_to_sphere, 0.0, 0.0, 0.0, 2.0)
+        with OutOfRange.set_treatment('nan'):
+            # Bad el0 > 90 degrees
+            ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
+            # Bad (x, y) vector length > 1.0
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 2.0, 0.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
+            ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 2.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
+            # Bad x coordinate > cos(el0)
+            ae = np.array(self.plane_to_sphere(0.0, np.pi / 2.0, 1.0, 0.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
+            ae = np.array(self.plane_to_sphere(0.0, np.pi / 2.0, -1.0, 0.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
+            # Bad y coordinate -> den < 0
+            ae = np.array(self.plane_to_sphere(0.0, np.pi / 2.0, 0.0, -1.0))
+            np.testing.assert_array_equal(ae, [np.nan, np.nan])
         with OutOfRange.set_treatment('clip'):
             ae = np.array(self.plane_to_sphere(0.0, np.pi, 0.0, 0.0))
             assert_angles_almost_equal(ae, [0.0, np.pi / 2.0], decimal=12)

--- a/katpoint/test/test_projection.py
+++ b/katpoint/test/test_projection.py
@@ -22,7 +22,7 @@ import unittest
 import numpy as np
 
 import katpoint
-from katpoint.projection import OutOfRange, ProjectionInputsOutOfRangeError
+from katpoint.projection import OutOfRange, OutOfRangeError
 
 try:
     from .aips_projection import newpos, dircos
@@ -67,11 +67,8 @@ class TestOutOfRangeTreatment(unittest.TestCase):
         y = OutOfRange.treat(x, 'Should not happen', lower=0, upper=5)
         np.testing.assert_array_equal(y, x)
         with OutOfRange.set_treatment('raise'):
-            with self.assertRaises(ProjectionInputsOutOfRangeError):
+            with self.assertRaises(OutOfRangeError):
                 y = OutOfRange.treat(x, 'Out of range', lower=2.1)
-        with OutOfRange.set_treatment('nan'):
-            y = OutOfRange.treat(x, 'Out of range', lower=2.1)
-            np.testing.assert_array_equal(y, [np.nan, np.nan, 3.0, 4.0])
         with OutOfRange.set_treatment('clip'):
             y = OutOfRange.treat(x, 'Out of range', upper=1.1)
             np.testing.assert_array_equal(y, [1.0, 1.1, 1.1, 1.1])
@@ -81,11 +78,8 @@ class TestOutOfRangeTreatment(unittest.TestCase):
         y = OutOfRange.treat(x, 'Should not happen', lower=0, upper=5)
         np.testing.assert_array_equal(y, x)
         with OutOfRange.set_treatment('raise'):
-            with self.assertRaises(ProjectionInputsOutOfRangeError):
+            with self.assertRaises(OutOfRangeError):
                 y = OutOfRange.treat(x, 'Out of range', lower=2.1)
-        with OutOfRange.set_treatment('nan'):
-            y = OutOfRange.treat(x, 'Out of range', lower=2.1)
-            np.testing.assert_array_equal(y, np.nan)
         with OutOfRange.set_treatment('clip'):
             y = OutOfRange.treat(x, 'Out of range', upper=1.1)
             np.testing.assert_array_equal(y, 1.1)

--- a/katpoint/test/test_projection.py
+++ b/katpoint/test/test_projection.py
@@ -659,7 +659,7 @@ class TestProjectionSTG(unittest.TestCase):
             xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
             np.testing.assert_almost_equal(xy, [0.0, -2.0], decimal=12)
             xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
-            np.testing.assert_almost_equal(xy, [-888.8873888868487, 0.0], decimal=12)
+            np.testing.assert_almost_equal(xy, [-894.42495493, 0.0], decimal=8)
             xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
             np.testing.assert_almost_equal(xy, [0.0, 2.0], decimal=12)
 

--- a/katpoint/test/test_projection.py
+++ b/katpoint/test/test_projection.py
@@ -43,7 +43,12 @@ def skip(reason=''):
 def assert_angles_almost_equal(x, y, decimal):
     def primary_angle(x):
         return x - np.round(x / (2.0 * np.pi)) * 2.0 * np.pi
-    np.testing.assert_almost_equal(primary_angle(x - y), np.zeros(np.shape(x)), decimal=decimal)
+    x = np.asarray(x)
+    y = np.asarray(y)
+    np.testing.assert_array_equal(0 * x, 0 * y,
+                                  'Array shapes and/or NaN patterns differ')
+    d = primary_angle(np.nan_to_num(x - y))
+    np.testing.assert_almost_equal(d, np.zeros(np.shape(x)), decimal=decimal)
 
 
 class TestOutOfRangeTreatment(unittest.TestCase):
@@ -197,7 +202,7 @@ class TestProjectionSIN(unittest.TestCase):
             xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
             np.testing.assert_almost_equal(xy, [0.0, -1.0], decimal=12)
             xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
-            np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=12)
+            np.testing.assert_almost_equal(xy, [-1.0, 0.0], decimal=12)
             xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
             np.testing.assert_almost_equal(xy, [0.0, 1.0], decimal=12)
 
@@ -331,11 +336,11 @@ class TestProjectionTAN(unittest.TestCase):
                               self.sphere_to_plane, 0.0, 0.0, 0.0, np.pi)
         with OutOfRange.set_treatment('clip'):
             xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
-            np.testing.assert_almost_equal(xy, [0.0, -1e5], decimal=11)
+            np.testing.assert_almost_equal(xy, [0.0, -1e6], decimal=4)
             xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
-            np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=11)
+            np.testing.assert_almost_equal(xy, [-1e6, 0.0], decimal=4)
             xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
-            np.testing.assert_almost_equal(xy, [0.0, 1e5], decimal=11)
+            np.testing.assert_almost_equal(xy, [0.0, 1e6], decimal=4)
 
         # PLANE TO SPHERE
         # Points outside allowed domain in plane
@@ -599,7 +604,7 @@ class TestProjectionSTG(unittest.TestCase):
             xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
             np.testing.assert_almost_equal(xy, [0.0, -2.0], decimal=12)
             xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
-            np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=10)
+            np.testing.assert_almost_equal(xy, [-888.8873888868487, 0.0], decimal=12)
             xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
             np.testing.assert_almost_equal(xy, [0.0, 2.0], decimal=12)
 
@@ -757,7 +762,7 @@ class TestProjectionSSN(unittest.TestCase):
             xy = np.array(self.sphere_to_plane(0.0, np.pi, 0.0, 0.0))
             np.testing.assert_almost_equal(xy, [0.0, 1.0], decimal=12)
             xy = np.array(self.sphere_to_plane(0.0, 0.0, np.pi, 0.0))
-            np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=12)
+            np.testing.assert_almost_equal(xy, [-1.0, 0.0], decimal=12)
             xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
             np.testing.assert_almost_equal(xy, [0.0, -1.0], decimal=12)
 

--- a/katpoint/test/test_projection.py
+++ b/katpoint/test/test_projection.py
@@ -170,9 +170,8 @@ class TestProjectionSIN(unittest.TestCase):
         np.testing.assert_almost_equal(xx, x_aips, decimal=9)
         np.testing.assert_almost_equal(yy, y_aips, decimal=9)
 
-    def test_corner_cases(self):
-        """SIN projection: test special corner cases."""
-        # SPHERE TO PLANE
+    def test_corner_cases_sphere_to_plane(self):
+        """SIN projection: test special corner cases (sphere->plane)."""
         # Origin
         xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, 0.0))
         np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=12)
@@ -195,7 +194,8 @@ class TestProjectionSIN(unittest.TestCase):
         xy = np.array(self.sphere_to_plane(0.0, np.pi / 2.0, -np.pi / 2.0, 0.0))
         np.testing.assert_almost_equal(xy, [-1.0, 0.0], decimal=12)
 
-        # PLANE TO SPHERE
+    def test_corner_cases_plane_to_sphere(self):
+        """SIN projection: test special corner cases (plane->sphere)."""
         # Origin
         ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 0.0))
         assert_angles_almost_equal(ae, [0.0, 0.0], decimal=12)
@@ -218,9 +218,8 @@ class TestProjectionSIN(unittest.TestCase):
         ae = np.array(self.plane_to_sphere(0.0,  -np.pi / 2.0, 0.0, -1.0))
         assert_angles_almost_equal(ae, [np.pi, 0.0], decimal=12)
 
-    def test_out_of_range_cases(self):
-        """SIN projection: test out-of-range cases."""
-        # SPHERE TO PLANE
+    def test_out_of_range_cases_sphere_to_plane(self):
+        """SIN projection: test out-of-range cases (sphere->plane)."""
         # Points outside allowed domain on sphere
         with out_of_range_context('raise'):
             self.assertRaises(OutOfRangeError,
@@ -244,7 +243,8 @@ class TestProjectionSIN(unittest.TestCase):
             xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
             np.testing.assert_almost_equal(xy, [0.0, 1.0], decimal=12)
 
-        # PLANE TO SPHERE
+    def test_out_of_range_cases_plane_to_sphere(self):
+        """SIN projection: test out-of-range cases (plane->sphere)."""
         # Points outside allowed domain in plane
         with out_of_range_context('raise'):
             self.assertRaises(OutOfRangeError,
@@ -321,9 +321,8 @@ class TestProjectionTAN(unittest.TestCase):
         np.testing.assert_almost_equal(xx, x_aips, decimal=10)
         np.testing.assert_almost_equal(yy, y_aips, decimal=10)
 
-    def test_corner_cases(self):
-        """TAN projection: test special corner cases."""
-        # SPHERE TO PLANE
+    def test_corner_cases_sphere_to_plane(self):
+        """TAN projection: test special corner cases (sphere->plane)."""
         # Origin
         xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, 0.0))
         np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=12)
@@ -346,7 +345,8 @@ class TestProjectionTAN(unittest.TestCase):
         xy = np.array(self.sphere_to_plane(0.0, np.pi / 2.0, -np.pi / 2.0, np.pi / 4.0))
         np.testing.assert_almost_equal(xy, [-1.0, 0.0], decimal=12)
 
-        # PLANE TO SPHERE
+    def test_corner_cases_plane_to_sphere(self):
+        """TAN projection: test special corner cases (plane->sphere)."""
         # Origin
         ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 0.0))
         assert_angles_almost_equal(ae, [0.0, 0.0], decimal=12)
@@ -369,9 +369,8 @@ class TestProjectionTAN(unittest.TestCase):
         ae = np.array(self.plane_to_sphere(0.0,  -np.pi / 2.0, 0.0, -1.0))
         assert_angles_almost_equal(ae, [np.pi, -np.pi / 4.0], decimal=12)
 
-    def test_out_of_range_cases(self):
-        """TAN projection: test out-of-range cases."""
-        # SPHERE TO PLANE
+    def test_out_of_range_cases_sphere_to_plane(self):
+        """TAN projection: test out-of-range cases (sphere->plane)."""
         # Points outside allowed domain on sphere
         with out_of_range_context('raise'):
             self.assertRaises(OutOfRangeError,
@@ -395,7 +394,8 @@ class TestProjectionTAN(unittest.TestCase):
             xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
             np.testing.assert_almost_equal(xy, [0.0, 1e6], decimal=4)
 
-        # PLANE TO SPHERE
+    def test_out_of_range_cases_plane_to_sphere(self):
+        """TAN projection: test out-of-range cases (plane->sphere)."""
         # Points outside allowed domain in plane
         with out_of_range_context('raise'):
             self.assertRaises(OutOfRangeError,
@@ -456,9 +456,8 @@ class TestProjectionARC(unittest.TestCase):
         np.testing.assert_almost_equal(xx, x_aips, decimal=8)
         np.testing.assert_almost_equal(yy, y_aips, decimal=8)
 
-    def test_corner_cases(self):
-        """ARC projection: test special corner cases."""
-        # SPHERE TO PLANE
+    def test_corner_cases_sphere_to_plane(self):
+        """ARC projection: test special corner cases (sphere->plane)."""
         # Origin
         xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, 0.0))
         np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=12)
@@ -484,7 +483,8 @@ class TestProjectionARC(unittest.TestCase):
         xy = np.array(self.sphere_to_plane(np.pi, 0.0, 0.0, 0.0))
         np.testing.assert_almost_equal(np.abs(xy), [np.pi, 0.0], decimal=12)
 
-        # PLANE TO SPHERE
+    def test_corner_cases_plane_to_sphere(self):
+        """ARC projection: test special corner cases (plane->sphere)."""
         # Origin
         ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 0.0))
         assert_angles_almost_equal(ae, [0.0, 0.0], decimal=12)
@@ -516,9 +516,8 @@ class TestProjectionARC(unittest.TestCase):
         ae = np.array(self.plane_to_sphere(0.0,  -np.pi / 2.0, 0.0, -np.pi / 2.0))
         assert_angles_almost_equal(ae, [np.pi, 0.0], decimal=12)
 
-    def test_out_of_range_cases(self):
-        """ARC projection: test out-of-range cases."""
-        # SPHERE TO PLANE
+    def test_out_of_range_cases_sphere_to_plane(self):
+        """ARC projection: test out-of-range cases (sphere->plane)."""
         # Points outside allowed domain on sphere
         with out_of_range_context('raise'):
             self.assertRaises(OutOfRangeError,
@@ -536,7 +535,8 @@ class TestProjectionARC(unittest.TestCase):
             xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
             np.testing.assert_almost_equal(xy, [0.0, np.pi / 2.0], decimal=12)
 
-        # PLANE TO SPHERE
+    def test_out_of_range_cases_plane_to_sphere(self):
+        """ARC projection: test out-of-range cases (plane->sphere)."""
         # Points outside allowed domain in plane
         with out_of_range_context('raise'):
             self.assertRaises(OutOfRangeError,
@@ -611,9 +611,8 @@ class TestProjectionSTG(unittest.TestCase):
         np.testing.assert_almost_equal(xx, x_aips, decimal=9)
         np.testing.assert_almost_equal(yy, y_aips, decimal=9)
 
-    def test_corner_cases(self):
-        """STG projection: test special corner cases."""
-        # SPHERE TO PLANE
+    def test_corner_cases_sphere_to_plane(self):
+        """STG projection: test special corner cases (sphere->plane)."""
         # Origin
         xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, 0.0))
         np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=12)
@@ -636,7 +635,8 @@ class TestProjectionSTG(unittest.TestCase):
         xy = np.array(self.sphere_to_plane(0.0, np.pi / 2.0, -np.pi / 2.0, 0.0))
         np.testing.assert_almost_equal(xy, [-2.0, 0.0], decimal=12)
 
-        # PLANE TO SPHERE
+    def test_corner_cases_plane_to_sphere(self):
+        """STG projection: test special corner cases (plane->sphere)."""
         # Origin
         ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 0.0))
         assert_angles_almost_equal(ae, [0.0, 0.0], decimal=12)
@@ -659,9 +659,8 @@ class TestProjectionSTG(unittest.TestCase):
         ae = np.array(self.plane_to_sphere(0.0,  -np.pi / 2.0, 0.0, -2.0))
         assert_angles_almost_equal(ae, [np.pi, 0.0], decimal=12)
 
-    def test_out_of_range_cases(self):
-        """STG projection: test out-of-range cases."""
-        # SPHERE TO PLANE
+    def test_out_of_range_cases_sphere_to_plane(self):
+        """STG projection: test out-of-range cases (sphere->plane)."""
         # Points outside allowed domain on sphere
         with out_of_range_context('raise'):
             self.assertRaises(OutOfRangeError,
@@ -685,7 +684,8 @@ class TestProjectionSTG(unittest.TestCase):
             xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
             np.testing.assert_almost_equal(xy, [0.0, 2.0], decimal=12)
 
-        # PLANE TO SPHERE
+    def test_out_of_range_cases_plane_to_sphere(self):
+        """STG projection: test out-of-range cases (plane->sphere)."""
         # Points outside allowed domain in plane
         with out_of_range_context('raise'):
             self.assertRaises(OutOfRangeError,
@@ -780,9 +780,8 @@ class TestProjectionSSN(unittest.TestCase):
         assert_angles_almost_equal(az, aa, decimal=10)
         assert_angles_almost_equal(el, ee, decimal=10)
 
-    def test_corner_cases(self):
-        """SSN projection: test special corner cases."""
-        # SPHERE TO PLANE
+    def test_corner_cases_sphere_to_plane(self):
+        """SSN projection: test special corner cases (sphere->plane)."""
         # Origin
         xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, 0.0))
         np.testing.assert_almost_equal(xy, [0.0, 0.0], decimal=12)
@@ -805,7 +804,8 @@ class TestProjectionSSN(unittest.TestCase):
         xy = np.array(self.sphere_to_plane(0.0, np.pi / 2.0, -np.pi / 2.0, 0.0))
         np.testing.assert_almost_equal(xy, [0.0, 1.0], decimal=12)
 
-        # PLANE TO SPHERE
+    def test_corner_cases_plane_to_sphere(self):
+        """SSN projection: test special corner cases (plane->sphere)."""
         # Origin
         ae = np.array(self.plane_to_sphere(0.0, 0.0, 0.0, 0.0))
         assert_angles_almost_equal(ae, [0.0, 0.0], decimal=12)
@@ -829,9 +829,8 @@ class TestProjectionSSN(unittest.TestCase):
         ae = np.array(self.plane_to_sphere(0.0, -1.0, 0.0, np.cos(1.0)))
         assert_angles_almost_equal(ae, [0.0, -np.pi / 2.0], decimal=12)
 
-    def test_out_of_range_cases(self):
-        """SSN projection: test out-of-range cases."""
-        # SPHERE TO PLANE
+    def test_out_of_range_cases_sphere_to_plane(self):
+        """SSN projection: test out-of-range cases (sphere->plane)."""
         # Points outside allowed domain on sphere
         with out_of_range_context('raise'):
             self.assertRaises(OutOfRangeError,
@@ -855,7 +854,8 @@ class TestProjectionSSN(unittest.TestCase):
             xy = np.array(self.sphere_to_plane(0.0, 0.0, 0.0, np.pi))
             np.testing.assert_almost_equal(xy, [0.0, -1.0], decimal=12)
 
-        # PLANE TO SPHERE
+    def test_out_of_range_cases_plane_to_sphere(self):
+        """SSN projection: test out-of-range cases (plane->sphere)."""
         # Points outside allowed domain in plane
         with out_of_range_context('raise'):
             self.assertRaises(OutOfRangeError,

--- a/katpoint/test/test_projection.py
+++ b/katpoint/test/test_projection.py
@@ -22,7 +22,7 @@ import unittest
 import numpy as np
 
 import katpoint
-from katpoint.projection import OutOfRange, OutOfRangeError
+from katpoint import OutOfRange, OutOfRangeError
 
 try:
     from .aips_projection import newpos, dircos

--- a/katpoint/test/test_projection.py
+++ b/katpoint/test/test_projection.py
@@ -96,6 +96,7 @@ class TestOutOfRangeTreatment(unittest.TestCase):
 class TestProjectionSIN(unittest.TestCase):
     """Test orthographic projection."""
     def setUp(self):
+        np.random.seed(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['SIN']
         self.sphere_to_plane = katpoint.sphere_to_plane['SIN']
         N = 100
@@ -227,6 +228,7 @@ class TestProjectionSIN(unittest.TestCase):
 class TestProjectionTAN(unittest.TestCase):
     """Test gnomonic projection."""
     def setUp(self):
+        np.random.seed(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['TAN']
         self.sphere_to_plane = katpoint.sphere_to_plane['TAN']
         N = 100
@@ -355,6 +357,7 @@ class TestProjectionTAN(unittest.TestCase):
 class TestProjectionARC(unittest.TestCase):
     """Test zenithal equidistant projection."""
     def setUp(self):
+        np.random.seed(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['ARC']
         self.sphere_to_plane = katpoint.sphere_to_plane['ARC']
         N = 100
@@ -495,6 +498,7 @@ class TestProjectionARC(unittest.TestCase):
 class TestProjectionSTG(unittest.TestCase):
     """Test stereographic projection."""
     def setUp(self):
+        np.random.seed(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['STG']
         self.sphere_to_plane = katpoint.sphere_to_plane['STG']
         N = 100
@@ -621,6 +625,7 @@ class TestProjectionSTG(unittest.TestCase):
 class TestProjectionCAR(unittest.TestCase):
     """Test plate carree projection."""
     def setUp(self):
+        np.random.seed(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['CAR']
         self.sphere_to_plane = katpoint.sphere_to_plane['CAR']
         N = 100
@@ -662,6 +667,7 @@ def plane_to_sphere_original_ssn(target_az, target_el, ll, mm):
 class TestProjectionSSN(unittest.TestCase):
     """Test swapped orthographic projection."""
     def setUp(self):
+        np.random.seed(42)
         self.plane_to_sphere = katpoint.plane_to_sphere['SSN']
         self.sphere_to_plane = katpoint.sphere_to_plane['SSN']
         N = 100


### PR DESCRIPTION
A comprehensive solution to @mattieudv's problems...

This PR handles out-of-range values in the spherical projection routines, inspired by NumPy's `seterr` machinery. We have the following set of functions in `katpoint.projection` and their NumPy equivalents:

  - np.seterr() -> set_out_of_range_treatment()
  - np.geterr() -> get_out_of_range_treatment()
  - np.errstate() -> out_of_range_context()
  - FloatingPointError -> OutOfRangeError
  - treat_out_of_range_values()

The following treatment options are available:

  - 'raise': raise `katpoint.projection.OutOfRangeError` (default)
  - 'nan': replace out-of-range values with NaNs
  - 'clip': replace out-of-range values with nearest valid values

The new `OutOfRangeError` exception is more specific but still derives from `ValueError` to maintain backwards compatibility. The default treatment is 'raise' for the same reason.

I will port this to ska-katpoint as well in due time.