### PR TITLE
Fix katpoint when called from non-main thread

### DIFF
--- a/katpoint/projection.py
+++ b/katpoint/projection.py
@@ -145,8 +145,11 @@ class OutOfRangeError(ValueError):
     """A numeric value is out of range."""
 
 
-_out_of_range_cvar = threading.local()
-_out_of_range_cvar.treatment = 'raise'
+class _OutOfRangeCvar(threading.local):
+    treatment = 'raise'
+
+
+_out_of_range_cvar = _OutOfRangeCvar()
 
 
 def set_out_of_range_treatment(treatment):


### PR DESCRIPTION
The out-of-range handling PR broke it, because it only set the treatment
on the thread-local object in the main thread. Using a subclass fixes
this because threads that don't explicitly set the treatment get the
default treatment from the class dictionary.