### PR TITLE
Depend on ephem rather than pyephem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ephem
 future
 numpy
-pyephem

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name="katpoint",
       install_requires=[
           "future",
           "numpy",
-          "pyephem",
+          "ephem",
       ],
       tests_require=[
           "nose",


### PR DESCRIPTION
These days `pyephem` is just a backwards-compatibility placeholder that
depends on `ephem` (https://pypi.org/project/pyephem/).