### PR TITLE
Add -c options to requirements files

### DIFF
--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e -x
 pip install -r ~/docker-base/pre-requirements.txt
-install-requirements.py -d ~/docker-base/base-requirements.txt -r requirements.txt -r test-requirements.txt
+pip install -r requirements.txt -r test-requirements.txt
 nosetests --with-xunit --with-coverage --cover-erase --cover-xml --cover-inclusive --cover-package=katpoint

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e -x
-pip install -r ~/docker-base/pre-requirements.txt
-pip install -r requirements.txt -r test-requirements.txt
-nosetests --with-xunit --with-coverage --cover-erase --cover-xml --cover-inclusive --cover-package=katpoint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "katversion"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+
 ephem
 future
 numpy

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+
 argparse; python_version<'3'        # via unittest2
 nose
 coverage


### PR DESCRIPTION
This makes it easier to install the right versions just with pip.

Also add a pyproject.toml to ensure katversion is available.

See SPR1-833.