### PR TITLE
SPR1-407 Allow fixed parameters during pointing model fitting

### DIFF
--- a/katpoint/pointing.py
+++ b/katpoint/pointing.py
@@ -23,6 +23,7 @@ from __future__ import print_function, division, absolute_import
 from builtins import range
 
 import logging
+import warnings
 
 import numpy as np
 
@@ -46,9 +47,9 @@ class PointingModel(Model):
 
     Parameters
     ----------
-    model : file-like object, sequence of 22 floats, or string, optional
-        Model specification. If this is a file-like object, load the model
-        from it. If this is a sequence of floats, accept it directly as the
+    model : :class:`PointingModel`, file-like, sequence of 22 floats, string, optional
+        Model specification. If this is a model or file-like object, load the
+        model from it. If this is a sequence of floats, accept it directly as the
         model parameters (defaults to sequence of zeroes). If it is a string,
         interpret it as a comma-separated (or whitespace-separated) sequence
         of parameters in their string form (i.e. a description string).
@@ -262,16 +263,24 @@ class PointingModel(Model):
                            iteration + 1, rad2deg(max_error) * 3600., max_az, max_el)
         return az, el
 
-    def fit(self, az, el, delta_az, delta_el, sigma_daz=None, sigma_del=None, enabled_params=None):
+    def fit(self, az, el, delta_az, delta_el, sigma_daz=None, sigma_del=None,
+            enabled_params=None, keep_disabled_params=False):
         """Fit pointing model parameters to observed offsets.
 
         This fits the pointing model to a sequence of observed (az, el) offsets.
-        A subset of the parameters can be fit, while the rest will be zeroed.
-        This is generally a good idea, as most of the parameters (P9 and above)
-        are ad hoc and should only be enabled if there are sufficient evidence
-        for them in the pointing error residuals. Standard errors can be
-        specified for the input offsets, and will be reflected in the returned
-        standard errors on the fitted parameters.
+        A subset of the parameters can be fit, while the rest will either be
+        kept (fixed) or zeroed. This is generally a good idea, as most of the
+        parameters (P9 and above) are ad hoc and should only be enabled if
+        there are sufficient evidence for them in the pointing error residuals.
+
+        While zeroing is the original behaviour, it is deprecated and will
+        eventually be removed, since the user can always explicitly zero the
+        model before calling :meth:`fit` to get the same result. The
+        contribution of fixed parameters will be subtracted from `delta_az`
+        and `delta_el` before the enabled parameters are fit to the residual.
+
+        Standard errors can be specified for the input offsets, and will be
+        reflected in the returned standard errors on the fitted parameters.
 
         Parameters
         ----------
@@ -287,6 +296,11 @@ class PointingModel(Model):
             integers start at **1** and correspond to the P-number. The default
             is to select the 6 main parameters modelling coordinate misalignment,
             which are P1, P3, P4, P5, P6 and P7.
+        keep_disabled_params : bool, optional
+            If True, disabled parameters (i.e. those that are not fitted)
+            keep their values and are treated as fixed / frozen parameters.
+            If False, they are zeroed. A future version of katpoint will
+            force this to be True and remove the parameter.
 
         Returns
         -------
@@ -320,9 +334,17 @@ class PointingModel(Model):
         assert az.shape == el.shape == delta_az.shape == delta_el.shape == sigma_daz.shape == sigma_del.shape, \
             'Input parameters should all have the same shape'
 
-        # Blank out the existing model
-        self.set()
+        if not keep_disabled_params:
+            # Blank out the existing model but warn that this behaviour is deprecated
+            self.set()
+            warnings.warn('Pointing model parameters that are not being fitted will be kept in '
+                          'future and not zeroed - zero the model beforehand instead', FutureWarning)
+        param_vector = np.array(self.values())
         sigma_params = np.zeros(len(self))
+        # Subtract the existing model from data (both enabled and disabled parameters)
+        fixed_delta_az, fixed_delta_el = self.offset(az, el)
+        residual_delta_az = delta_az - fixed_delta_az
+        residual_delta_el = delta_el - fixed_delta_el
 
         # Handle parameter enabling
         if enabled_params is None:
@@ -340,9 +362,9 @@ class PointingModel(Model):
             logger.warning('Pointing model parameter P10 is redundant for alt-az mount (same as P8) - disabled P10')
             enabled_params.remove(10)
         enabled_params = np.array(list(enabled_params))
-        # If no parameters are enabled, a zero model is returned
+        # If no parameters are enabled, the existing model is returned
         if len(enabled_params) == 0:
-            return np.array(self.values()), sigma_params
+            return param_vector, sigma_params
 
         # Number of active parameters
         M = len(enabled_params)
@@ -351,22 +373,21 @@ class PointingModel(Model):
         N = 2 * len(az)
         # Construct design matrix, containing weighted basis functions
         A = np.zeros((N, M))
-        param_vector = np.zeros(len(self))
         for m, param in enumerate(enabled_params):
             # Create parameter vector that will select a single column of design matrix
-            param_vector[:] = 0.0
-            param_vector[param - 1] = 1.0
-            self.fromlist(param_vector)
-            basis_az, basis_el = self.offset(az, el)
+            unit_vector = np.zeros(len(self))
+            unit_vector[param - 1] = 1.0
+            unit_model = PointingModel(unit_vector)
+            basis_az, basis_el = unit_model.offset(az, el)
             A[:, m] = np.hstack((basis_az * cos_el / sigma_daz, basis_el / sigma_del))
         # Measurement vector, containing weighted observed offsets
-        b = np.hstack((delta_az * cos_el / sigma_daz, delta_el / sigma_del))
+        b = np.hstack((residual_delta_az * cos_el / sigma_daz, residual_delta_el / sigma_del))
         # Solve linear least-squares problem using SVD (see NRinC, 2nd ed, Eq. 15.4.17)
         U, s, Vt = np.linalg.svd(A, full_matrices=False)
-        param_vector[enabled_params - 1] = np.dot(Vt.T, np.dot(U.T, b) / s)
+        # We solved on the residual (az, el) offsets, so add the solution to existing parameters
+        param_vector[enabled_params - 1] += Vt.T.dot(U.T.dot(b) / s)
         self.fromlist(param_vector)
         # Also obtain standard errors of parameters (see NRinC, 2nd ed, Eq. 15.4.19)
         sigma_params[enabled_params - 1] = np.sqrt(np.sum((Vt.T / s[np.newaxis, :]) ** 2, axis=1))
 #        logger.info('Fit pointing model using %dx%d design matrix with condition number %.2f', N, M, s[0] / s[-1])
-
         return param_vector, sigma_params

--- a/katpoint/test/test_pointing.py
+++ b/katpoint/test/test_pointing.py
@@ -17,7 +17,13 @@
 """Tests for the pointing module."""
 from __future__ import print_function, division, absolute_import
 
-import unittest
+import sys
+import warnings
+
+if sys.version_info < (3,):
+    import unittest2 as unittest
+else:
+    import unittest
 
 import numpy as np
 
@@ -79,11 +85,37 @@ class TestPointingModel(unittest.TestCase):
         params[1] = params[9] = 0.0
         pm = katpoint.PointingModel(params.copy())
         delta_az, delta_el = pm.offset(self.az, self.el)
+        # All parameters are enabled
         enabled_params = (np.arange(self.num_params) + 1).tolist()
-        # Comment out these removes, thereby testing more code paths in PointingModel
-        # enabled_params.remove(2)
-        # enabled_params.remove(10)
-        fitted_params, sigma_params = pm.fit(self.az, self.el, delta_az, delta_el, enabled_params=[])
+        # Don't fit anything, but keep existing model
+        fitted_params, sigma_params = pm.fit(self.az, self.el, delta_az, delta_el,
+                                             enabled_params=[], keep_disabled_params=True)
+        np.testing.assert_equal(fitted_params, params)
+        np.testing.assert_equal(sigma_params, np.zeros(self.num_params))
+        with self.assertWarns(FutureWarning):
+            # Don't fit anything, and zero the model (deprecated)
+            fitted_params, _ = pm.fit(self.az, self.el, delta_az, delta_el, enabled_params=[])
         np.testing.assert_equal(fitted_params, np.zeros(self.num_params))
-        fitted_params, sigma_params = pm.fit(self.az, self.el, delta_az, delta_el, enabled_params=enabled_params)
+        # Clear model explicitly and fit all parameters
+        pm.set()
+        fitted_params, _ = pm.fit(self.az, self.el, delta_az, delta_el,
+                                  enabled_params=enabled_params, keep_disabled_params=True)
         np.testing.assert_almost_equal(fitted_params, params, decimal=9)
+        np.testing.assert_equal(fitted_params, pm.values())
+        # Don't clear model and refit all parameters - same result
+        fitted_params, _ = pm.fit(self.az, self.el, delta_az, delta_el,
+                                  enabled_params=enabled_params, keep_disabled_params=True)
+        np.testing.assert_almost_equal(fitted_params, params, decimal=9)
+        # Fit some different parameters and keep the rest
+        pm = katpoint.PointingModel(params.copy())
+        fitted_params, _ = pm.fit(self.az, self.el, delta_az + 0.001, delta_el,
+                                  enabled_params=[1, 2, 3], keep_disabled_params=True)
+        self.assertRaises(AssertionError, np.testing.assert_equal, fitted_params[:3], params[:3])
+        np.testing.assert_equal(fitted_params[3:], params[3:])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # Fit some different parameters and zero the rest
+            fitted_params, _ = pm.fit(self.az, self.el, delta_az + 0.001, delta_el,
+                                      enabled_params=[1, 2, 3], keep_disabled_params=False)
+        self.assertRaises(AssertionError, np.testing.assert_equal, fitted_params[:3], params[:3])
+        np.testing.assert_equal(fitted_params[3:], np.zeros(self.num_params - 3))


### PR DESCRIPTION
Allow pointing model parameters to be fixed to their old values by
introducing a `keep_disabled_params` parameter to `PointingModel.fit()`.
If True, the old model values are kept and subtracted from the data
before fitting the enabled parameters. These residual fits are then
added back to the original parameters to arrive at the final parameters.

If False (the default for now and the original behaviour), all model
parameters are first zeroed before fitting the enabled parameters.
This behaviour is deprecated and `keep_disabled_params` will be forced
to True and removed in a future release. The original behaviour can be
achieved by explicitly zeroing the model before calling `fit()`. Warn
the user about this.

Clean up `fit()` by not abusing `self` to generate columns in the
design matrix. Improve the docstring for `PointingModel` by pointing
out that it can be initialised from an existing model. Add unit tests
to check treatment of enabled and disabled parameters.