### PR TITLE
MKAIV-1555 Fix sign of NIAO term in delay model

### DIFF
--- a/katpoint/delay.py
+++ b/katpoint/delay.py
@@ -246,8 +246,8 @@ class DelayCorrection(object):
                                                 antenna=self.ref_ant, **offset)
         targetdir = np.array(azel_to_enu(az, el))
         cos_el = np.cos(el)
-        design_mat = np.array([np.r_[-targetdir, 1.0, 0.0, cos_el],
-                               np.r_[-targetdir, 0.0, 1.0, cos_el]])
+        design_mat = np.array([np.r_[-targetdir, 1.0, 0.0, -cos_el],
+                               np.r_[-targetdir, 0.0, 1.0, -cos_el]])
         return np.dot(self._params, design_mat.T).ravel()
 
     def _cached_delays(self, target, timestamp, offset=None):


### PR DESCRIPTION
The non-intersecting axis offset is typically +1.0 m for MeerKAT and brings the dish closer to the source at low elevations. It should therefore behave like a shorter cable and reduce the calculated delay. Achieve this by adding a minus sign to the cos(el) scale factor.

This mirrors [SPAZA-288](https://jira.skatelescope.org/browse/SPAZA-288) which updated katpoint v1 in a similar way. The change to katpoint v0 behaviour should be minimal, since all dishes share the same array-level elevation and they typically also have the same NIAO value for MeerKAT. The relative delay per baseline pair is therefore identical, and only absolute delay is affected.