### PR TITLE
SPR1-900 Handle katpoint v1 description strings in v0

### DIFF
--- a/katpoint/ephem_extra.py
+++ b/katpoint/ephem_extra.py
@@ -78,12 +78,12 @@ def _to_angle(s, unit='d'):
         unit = suffix
         s = s[:-1]
     # Pick appropriate converter based on unit
-    if unit in ('d', 'deg', 'degrees'):
+    if unit == 'd':
         converter = ephem.degrees
-    elif unit in ('h', 'hour', 'hourangle', 'hours'):
+    elif unit == 'h':
         converter = ephem.hours
     else:
-        raise ValueError(f"Unsupported angle unit {unit}, must be 'deg' or 'hour'")
+        raise ValueError("Unsupported angle unit '{}', must be 'd' or 'h'".format(unit))
     try:
         # Ephem expects a number or platform-appropriate string (i.e. Unicode on Py3)
         return converter(s)
@@ -94,12 +94,12 @@ def _to_angle(s, unit='d'):
 
 def angle_from_degrees(s):
     """Creates angle object from sexagesimal string in degrees or number in radians."""
-    return _to_angle(s, unit='d')
+    return ephem.degrees(_to_angle(s, unit='d'))
 
 
 def angle_from_hours(s):
     """Creates angle object from sexagesimal string in hours or number in radians."""
-    return _to_angle(s, unit='h')
+    return ephem.hours(_to_angle(s, unit='h'))
 
 
 def wrap_angle(angle, period=2.0 * np.pi):

--- a/katpoint/ephem_extra.py
+++ b/katpoint/ephem_extra.py
@@ -67,24 +67,39 @@ def _just_gimme_an_ascii_string(s):
         return str(s)
 
 
-def angle_from_degrees(s):
-    """Creates angle object from sexagesimal string in degrees or number in radians."""
+def _to_angle(s, unit='d'):
+    """Creates angle object from sexagesimal string with given `unit` or number in radians."""
+    # Try to obtain the unit from a string suffix (this is the v1 angle format)
+    try:
+        suffix = _just_gimme_an_ascii_string(s[-1])
+    except (TypeError, IndexError):
+        suffix = ''
+    if suffix in ('d', 'h'):
+        unit = suffix
+        s = s[:-1]
+    # Pick appropriate converter based on unit
+    if unit in ('d', 'deg', 'degrees'):
+        converter = ephem.degrees
+    elif unit in ('h', 'hour', 'hourangle', 'hours'):
+        converter = ephem.hours
+    else:
+        raise ValueError(f"Unsupported angle unit {unit}, must be 'deg' or 'hour'")
     try:
         # Ephem expects a number or platform-appropriate string (i.e. Unicode on Py3)
-        return ephem.degrees(s)
+        return converter(s)
     except TypeError:
         # If input is neither, assume that it really wants to be a string
-        return ephem.degrees(_just_gimme_an_ascii_string(s))
+        return converter(_just_gimme_an_ascii_string(s))
+
+
+def angle_from_degrees(s):
+    """Creates angle object from sexagesimal string in degrees or number in radians."""
+    return _to_angle(s, unit='d')
 
 
 def angle_from_hours(s):
     """Creates angle object from sexagesimal string in hours or number in radians."""
-    try:
-        # Ephem expects a number or platform-appropriate string (i.e. Unicode on Py3)
-        return ephem.hours(s)
-    except TypeError:
-        # If input is neither, assume that it really wants to be a string
-        return ephem.hours(_just_gimme_an_ascii_string(s))
+    return _to_angle(s, unit='h')
 
 
 def wrap_angle(angle, period=2.0 * np.pi):

--- a/katpoint/target.py
+++ b/katpoint/target.py
@@ -1028,13 +1028,13 @@ def construct_target_params(description):
         if len(fields) < 4:
             raise ValueError("Target description '%s' contains *gal* body with no (l, b) coordinates"
                              % description)
-        l, b = float(fields[2]), float(fields[3])
+        l, b = angle_from_degrees(fields[2]), angle_from_degrees(fields[3])
         body = ephem.FixedBody()
-        ra, dec = ephem.Galactic(deg2rad(l), deg2rad(b)).to_radec()
+        ra, dec = ephem.Galactic(l, b).to_radec()
         if preferred_name:
             body.name = preferred_name
         else:
-            body.name = "Galactic l: %.4f b: %.4f" % (l, b)
+            body.name = "Galactic l: %.4f b: %.4f" % (rad2deg(l), rad2deg(b))
         body._epoch = ephem.J2000
         body._ra = ra
         body._dec = dec

--- a/katpoint/target.py
+++ b/katpoint/target.py
@@ -56,9 +56,17 @@ class Target(object):
     the list may be empty. The <tags> field contains a space-separated list of
     descriptive tags for the target. The first tag is mandatory and indicates
     the body type of the target, which should be one of (*azel*, *radec*, *gal*,
-    *tle*, *special*, *star*, *xephem*). The longidutinal and latitudinal fields
-    are only relevant to *azel* and *radec* targets, in which case they contain
-    the relevant coordinates.
+    *tle*, *special*, *star*, *xephem*).
+
+    The longitudinal and latitudinal fields are only relevant to *azel*, *radec*
+    and *gal* targets, in which case they contain the relevant coordinates. The
+    following angle string formats are supported::
+
+      - Decimal, always in degrees (e.g. '12.5')
+      - Sexagesimal, in hours for right ascension and degrees for the rest,
+        with a colon or space separator (e.g. '12:30:00' or '12 30')
+      - Decimal or sexagesimal with explicit unit suffix 'd' or 'h',
+        e.g. '12.5h' (hours, not degrees!) or '12:30d'
 
     The <flux model> is a space-separated list of numbers used to represent the
     flux density of the target. The first two numbers specify the frequency
@@ -1119,10 +1127,10 @@ def construct_azel_target(az, el):
 
     Parameters
     ----------
-    az : string or float
-        Azimuth, either in 'D:M:S' string format, or as a float in radians
-    el : string or float
-        Elevation, either in 'D:M:S' string format, or as a float in radians
+    az, el : string or float
+        Azimuth / elevation, either as a sexagesimal or decimal string in degrees,
+        or such a string with an explicit unit suffix ('d' for degrees / 'h' for
+        hours), or as a float in radians
 
     Returns
     -------
@@ -1146,11 +1154,13 @@ def construct_radec_target(ra, dec):
     Parameters
     ----------
     ra : string or float
-        Right ascension, either in 'H:M:S' or decimal degree string format, or
-        as a float in radians
+        Right ascension, either as a sexagesimal string in hours, a decimal
+        string in degrees, or a sexagesimal or decimal string with an explicit
+        unit suffix ('d' for degrees / 'h' for hours), or as a float in radians
     dec : string or float
-        Declination, either in 'D:M:S' or decimal degree string format, or as
-        a float in radians
+        Declination, either as a sexagesimal or decimal string in degrees, or
+        such a string with an explicit unit suffix ('d' for degrees / 'h' for
+        hours), or as a float in radians
 
     Returns
     -------

--- a/katpoint/test/test_target.py
+++ b/katpoint/test/test_target.py
@@ -33,12 +33,15 @@ class TestTargetConstruction(unittest.TestCase):
     """Test construction of targets from strings and vice versa."""
     def setUp(self):
         self.valid_targets = ['azel, -30.0, 90.0',
+                              'azel, -30.0d, 90.0d',
                               ', azel, 180, -45:00:00.0',
                               'Zenith, azel, 0, 90',
                               'radec J2000, 0, 0.0, (1000.0 2000.0 1.0 10.0)',
                               ', radec B1950, 14:23:45.6, -60:34:21.1',
                               'radec B1900, 14:23:45.6, -60:34:21.1',
+                              'radec B1900, 14:23:45.6h, -60:34:21.1d',
                               'gal, 300.0, 0.0',
+                              'gal, 300.0d, 0.0d',
                               'Sag A, gal, 0.0, 0.0',
                               'Zizou, radec cal, 1.4, 30.0, (1000.0 2000.0 1.0 10.0)',
                               'Fluffy | *Dinky, radec, 12.5, -50.0, (1.0 2.0 1.0 2.0 3.0 4.0)',
@@ -65,6 +68,8 @@ class TestTargetConstruction(unittest.TestCase):
                                 'Zenith, azel blah',
                                 'radec J2000, 0.3',
                                 'gal, 0.0',
+                                'gal, 0.0deg, 0.0deg',
+                                'gal, 0.0rad, 0.0rad',
                                 'Zizou, radec cal, 1.4, 30.0, (1000.0, 2000.0, 1.0, 10.0)',
                                 'tle, GPS BIIA-21 (PRN 09)    \n' +
                                 '2 22700  55.4408  61.3790 0191986  78.1802 283.9935  2.00561720104282\n',
@@ -80,8 +85,8 @@ class TestTargetConstruction(unittest.TestCase):
         # A floating-point RA is in degrees
         self.radec_target = 'radec, 20.0, -20.0'
         # A sexagesimal RA string is in hours
-        self.radec_target_rahours = 'radec, 20:00:00, -20:00:00'
-        self.gal_target = 'gal, 30.0, -30.0'
+        self.radec_target_rahours = 'radec, 20:00:00h, -20:00:00'
+        self.gal_target = 'gal, 30.0d, -30.0d'
         self.tag_target = 'azel J2000 GPS, 40.0, -30.0'
 
     def test_construct_target(self):

--- a/katpoint/test/test_target.py
+++ b/katpoint/test/test_target.py
@@ -152,6 +152,11 @@ class TestTargetConstruction(unittest.TestCase):
         calc_l, calc_b = katpoint.rad2deg(calc_lb[0]), katpoint.rad2deg(calc_lb[1])
         np.testing.assert_almost_equal(calc_l, 30.0, decimal=4)
         np.testing.assert_almost_equal(calc_b, -30.0, decimal=4)
+        lb2 = katpoint.Target('gal, 4h, -4h')
+        calc_lb2 = lb2.galactic()
+        calc_l2, calc_b2 = katpoint.rad2deg(calc_lb2[0]), katpoint.rad2deg(calc_lb2[1])
+        np.testing.assert_almost_equal(calc_l2, 60.0, decimal=4)
+        np.testing.assert_almost_equal(calc_b2, -60.0, decimal=4)
 
     def test_add_tags(self):
         """Test adding tags."""


### PR DESCRIPTION
The new katpoint v1 stores angles with a unit suffix ('d' or 'h') in description strings, to improve Astropy compatibility.

Support these angle representations, and let the suffix unit override the suggested unit based on the body type. This preserves compatibility with future datasets that store v1 descriptions.

In the process, let `gal` Targets use full angle representations too instead of just plain floats.

Add some basic tests for this.