### PR TITLE
SPR1-2871: Fix deprecation issues

### DIFF
--- a/katpoint/model.py
+++ b/katpoint/model.py
@@ -231,7 +231,10 @@ class Model(object):
             File-like object with write() method representing config file
 
         """
-        cfg = configparser.SafeConfigParser()
+        if future.utils.PY2:
+            cfg = configparser.SafeConfigParser()
+        else:
+            cfg = configparser.ConfigParser()
         cfg.add_section('header')
         for key, val in self.header.items():
             cfg.set('header', key, str(val))
@@ -252,10 +255,12 @@ class Model(object):
         defaults = dict((p.name, p._to_str(p.default_value)) for p in self)
         if future.utils.PY2:
             cfg = configparser.SafeConfigParser(defaults)
+            read_file = cfg.readfp
         else:
             cfg = configparser.ConfigParser(defaults, inline_comment_prefixes=(';', '#'))
+            read_file = cfg.read_file
         try:
-            cfg.readfp(file_like)
+            read_file(file_like)
             if cfg.sections() != ['header', 'params']:
                 raise configparser.Error('Expected sections not found in model file')
         except configparser.Error as exc:

--- a/katpoint/pointing.py
+++ b/katpoint/pointing.py
@@ -351,7 +351,7 @@ class PointingModel(Model):
             enabled_params = [1, 3, 4, 5, 6, 7]
         enabled_params = np.asarray(enabled_params)
         # Convert boolean selection to integer indices
-        if enabled_params.dtype == np.bool:
+        if enabled_params.dtype == bool:
             enabled_params = enabled_params.nonzero()[0] + 1
         enabled_params = set(enabled_params)
         # Remove troublesome parameters if enabled


### PR DESCRIPTION
The following things break in numpy >= 1.24 and Python >= 3.12:

- `np.bool`   [use `bool`]
- `configparser.SafeConfigParser`  [use `configparser.ConfigParser`]
- `configparser.ConfigParser.readfp`. [use `configparser.ConfigParser.read_file`]

Once this is approved, I'll spin up a patch release as part of this PR.