### PR TITLE
SPR1-3161: Restore description strings in NumPy 2.0

### DIFF
--- a/katpoint/flux.py
+++ b/katpoint/flux.py
@@ -127,12 +127,17 @@ class FluxDensityModel(object):
         nondefault_coefs = np.nonzero(self.coefs != self._DEFAULT_COEFS)[0]
         last_nondefault_coef = nondefault_coefs[-1] if len(nondefault_coefs) > 0 else 0
         pruned_coefs = self.coefs[:last_nondefault_coef + 1]
-        self.description = '(%s %s %s)' % (min_freq_MHz, max_freq_MHz, ' '.join(['%r' % (c,) for c in pruned_coefs]))
+        self.description = '(%s %s %s)' % (
+            min_freq_MHz, max_freq_MHz, ' '.join([repr(float(c)) for c in pruned_coefs])
+        )
 
     def __str__(self):
         """Verbose human-friendly string representation."""
-        return "Flux density defined for %d-%d MHz, coefs=(%s)" % \
-               (self.min_freq_MHz, self.max_freq_MHz, ', '.join(['%r' % (c,) for c in self.coefs]))
+        return "Flux density defined for %d-%d MHz, coefs=(%s)" % (
+            self.min_freq_MHz,
+            self.max_freq_MHz,
+            ', '.join([repr(float(c)) for c in self.coefs]),
+        )
 
     def __repr__(self):
         """Short human-friendly string representation."""


### PR DESCRIPTION
Since NumPy 2.0 the `repr` of NumPy data types like `np.int64` contains the type. That is, `repr(np.int64(42))` now returns `"np.int64(42)"` instead of the plain `"42"`. This breaks the flux model description strings, where `repr` was previously introduced to preserve the precision of the coefficients. The solution is to cast the `np.float64` coefficients emerging from the ndarray to POD `float` before the `repr`.

We'll probably need a new release as well to save our users.

@KimMcAlpine, I'm nominating you since you touched that code last 😅 